### PR TITLE
[DT-223] Add support for using sdk with greenfield

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Create a simple client, specifying an application name:
 ```scala
 import com.cognite.sdk.scala.v1._
 
-val c = Client("scala-sdk-examples")
+val c = Client("scala-sdk-examples", "api.cognitedata.com")
 ```
 
 Create a client using the cats-effect `IO`:
@@ -39,7 +39,7 @@ import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 implicit val cs = IO.contextShift(ExecutionContext.fromExecutor(Executors.newCachedThreadPool()))
 implicit val sttpBackend = AsyncHttpClientCatsBackend[cats.effect.IO]()
-val c = Client("scala-sdk-examples")
+val c = Client("scala-sdk-examples", "api.cognite.com")
 ```
 
 The following examples will use `Client` with the identity effect.

--- a/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
@@ -7,29 +7,29 @@ import org.scalatest.{FlatSpec, Matchers}
 
 trait DataPointsResourceBehaviors[I] extends Matchers { this: FlatSpec =>
   private val startTime = System.currentTimeMillis()
-  private val endTime = startTime + 20*1000
-  private val testDataPoints = (startTime to endTime by 1000).map(t =>
-    DataPoint(Instant.ofEpochMilli(t), math.random))
+  private val endTime = startTime + 20 * 1000
+  private val testDataPoints =
+    (startTime to endTime by 1000).map(t => DataPoint(Instant.ofEpochMilli(t), math.random))
 
   def withTimeSeriesId(testCode: I => Any): Unit
 
-  def dataPointsResource(dataPoints: DataPointsResource[Id, I]): Unit = {
-    it should "be possible to insert and delete numerical data points" in withTimeSeriesId { timeSeriesId =>
-      dataPoints.insertById(timeSeriesId, testDataPoints)
+  def dataPointsResource(dataPoints: DataPointsResource[Id, I]): Unit =
+    it should "be possible to insert and delete numerical data points" in withTimeSeriesId {
+      timeSeriesId =>
+        dataPoints.insertById(timeSeriesId, testDataPoints)
 
-      Thread.sleep(3000)
-      val points = dataPoints.queryById(timeSeriesId, startTime, endTime + 1)
-      points should have size testDataPoints.size.toLong
+        Thread.sleep(15000)
+        val points = dataPoints.queryById(timeSeriesId, startTime, endTime + 1)
+        points should have size testDataPoints.size.toLong
 
-      val latest = dataPoints.getLatestDataPointById(timeSeriesId)
-      latest.isDefined should be (true)
-      val latestPoint = latest.get
-      testDataPoints.toList should contain (latestPoint)
+        val latest = dataPoints.getLatestDataPointById(timeSeriesId)
+        latest.isDefined should be(true)
+        val latestPoint = latest.get
+        testDataPoints.toList should contain(latestPoint)
 
-      dataPoints.deleteRangeById(timeSeriesId, startTime, endTime + 1)
-      Thread.sleep(10000)
-      val pointsAfterDelete = dataPoints.queryById(timeSeriesId, startTime, endTime + 1)
-      pointsAfterDelete should have size 0
+        dataPoints.deleteRangeById(timeSeriesId, startTime, endTime + 1)
+        Thread.sleep(15000)
+        val pointsAfterDelete = dataPoints.queryById(timeSeriesId, startTime, endTime + 1)
+        pointsAfterDelete should have size 0
     }
-  }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/LoginTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/LoginTest.scala
@@ -10,10 +10,10 @@ class LoginTest extends SdkTest {
     options = SttpBackendOptions.connectionTimeout(90.seconds)
   )
   it should "read login status" in {
-    val login = new Login(RequestSession(
-      "scala-sdk-test", uri"https://api.cognitedata.com", backend, auth))
+    val login =
+      new Login(RequestSession("scala-sdk-test", uri"https://api.cognitedata.com", backend, auth))
     val status = login.status()
-    status.loggedIn should be (true)
+    status.loggedIn should be(true)
     status.project should not be empty
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/SdkTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/SdkTest.scala
@@ -29,12 +29,26 @@ class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBacke
 }
 
 abstract class SdkTest extends FlatSpec with Matchers {
-  // Use this if you need request logs for debugging: new LoggingSttpBackend[Id, Nothing](sttpBackend)
-  val client = new GenericClient("scala-sdk-test")(implicitly[Monad[Id]], auth, sttpBackend)
+  val client = new GenericClient("scala-sdk-test")(
+    implicitly[Monad[Id]],
+    auth,
+    // Use this if you need request logs for debugging: new LoggingSttpBackend[Id, Nothing](sttpBackend)
+    sttpBackend
+  )
+
+  val greenfieldClient = new GenericClient(
+    "cdp-spark-datasource-test", "https://greenfield.cognitedata.com")(
+    implicitly[Monad[Id]],
+    greenfieldAuth,
+    sttpBackend
+  )
 
   def shortRandom(): String = UUID.randomUUID().toString.substring(0, 8)
 
   private lazy val apiKey = Option(System.getenv("TEST_API_KEY_READ"))
     .getOrElse(throw new RuntimeException("TEST_API_KEY_READ not set"))
   implicit lazy val auth: Auth = ApiKeyAuth(apiKey)
+  private lazy val greenfieldApiKey = Option(System.getenv("TEST_API_KEY_GREENFIELD"))
+    .getOrElse(throw new RuntimeException("TEST_API_KEY_GREENFIELD not set"))
+  implicit lazy val greenfieldAuth: Auth = ApiKeyAuth(greenfieldApiKey)
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -5,16 +5,22 @@ import com.cognite.sdk.scala.common.{ApiKeyAuth, Auth, InvalidAuthentication, Sd
 
 class ClientTest extends SdkTest {
   "Client" should "fetch the project using login/status if necessary" in {
-    noException should be thrownBy new GenericClient("scala-sdk-test")(
+    noException should be thrownBy new GenericClient(
+      "scala-sdk-test")(
       implicitly[Monad[Id]],
       auth,
       sttpBackend
     )
-    new GenericClient("scala-sdk-test")(implicitly[Monad[Id]], auth, sttpBackend).project should not be empty
+    new GenericClient("scala-sdk-test")(
+      implicitly[Monad[Id]],
+      auth,
+      sttpBackend
+    ).project should not be empty
   }
   it should "throw an exception if the authentication is invalid and project is not specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key")
-    an[InvalidAuthentication] should be thrownBy new GenericClient("scala-sdk-test")(
+    an[InvalidAuthentication] should be thrownBy new GenericClient(
+      "scala-sdk-test")(
       implicitly[Monad[Id]],
       auth,
       sttpBackend
@@ -22,10 +28,24 @@ class ClientTest extends SdkTest {
   }
   it should "not throw an exception if the authentication is invalid and project is specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key", project = Some("random-project"))
-    noException should be thrownBy new GenericClient("scala-sdk-test")(
+    noException should be thrownBy new GenericClient(
+      "scala-sdk-test")(
       implicitly[Monad[Id]],
       auth,
       sttpBackend
     )
   }
+
+  it should "be possible to use the sdk with greenfield.cognite.data.com" in {
+    implicit val auth: Auth = ApiKeyAuth(Option(System.getenv("TEST_API_KEY_GREENFIELD"))
+      .getOrElse(throw new RuntimeException("TEST_API_KEY_GREENFIELD not set")))
+    noException should be thrownBy new GenericClient(
+      "cdp-spark-datasource-test",
+      "https://greenfield.cognitedata.com"
+    )(implicitly[Monad[Id]],
+      auth,
+      sttpBackend
+    )
+  }
+
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
@@ -1,0 +1,20 @@
+package com.cognite.sdk.scala.v1
+
+import java.util.UUID
+
+import com.cognite.sdk.scala.common.{DataPointsResourceBehaviors, SdkTest}
+
+class GreenfieldDataPointsTest extends SdkTest with DataPointsResourceBehaviors[Long] {
+  override def withTimeSeriesId(testCode: Long => Any): Unit = {
+    val timeSeriesId = greenfieldClient.timeSeries.createFromRead(
+      Seq(TimeSeries(name = s"data-points-test-${UUID.randomUUID().toString}"))
+    ).head.id
+    try {
+      val _ = testCode(timeSeriesId)
+    } finally {
+      greenfieldClient.timeSeries.deleteByIds(Seq(timeSeriesId))
+    }
+  }
+
+  it should behave like dataPointsResource(greenfieldClient.dataPoints)
+}


### PR DESCRIPTION
- added baseUri parameter to Client and GenericClient and added "api.cognitedata.com" to existing tests that call either constructor
- tested using greenfield api-key and baseUri in ClientTest