### PR TITLE
Fix 3d asset mapping decoding error

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
@@ -60,8 +60,8 @@ final case class ThreeDRevisionUpdate(
 final case class ThreeDAssetMapping(
     nodeId: Long,
     assetId: Long,
-    treeIndex: Long = 0,
-    subtreeSize: Long = 0
+    treeIndex: Option[Long],
+    subtreeSize: Option[Long]
 )
 
 final case class ThreeDAssetMappingCreate(


### PR DESCRIPTION
From 3d backend team: "There are some edge cases where an asset mapping may exist, but the node it's connected to does not. In that case, treeIndex and subtreeSize do not exist and so they'll be missing. So that's probably an oversight in the docs, yes."

Fixed by making those two fields options