### PR TITLE
Make time series name optional

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
@@ -5,7 +5,7 @@ import java.time.Instant
 import com.cognite.sdk.scala.common.{NonNullableSetter, SearchQuery, Setter, WithExternalId, WithId}
 
 final case class TimeSeries(
-    name: String,
+    name: Option[String] = None,
     isString: Boolean = false,
     metadata: Option[Map[String, String]] = None,
     unit: Option[String] = None,
@@ -22,7 +22,7 @@ final case class TimeSeries(
 
 final case class TimeSeriesCreate(
     externalId: Option[String] = None,
-    name: String,
+    name: Option[String] = None,
     legacyName: Option[String] = None,
     isString: Boolean = false,
     metadata: Option[Map[String, String]] = None,

--- a/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
@@ -7,10 +7,10 @@ import com.cognite.sdk.scala.common.{CdpApiException, DataPointsResourceBehavior
 
 class DataPointsTest extends SdkTest with DataPointsResourceBehaviors {
   override def withTimeSeries(testCode: TimeSeries => Any): Unit = {
-    val name = s"data-points-test-${UUID.randomUUID().toString}"
+    val name = Some(s"data-points-test-${UUID.randomUUID().toString}")
     val timeSeries = client.timeSeries
       .createFromRead(
-        Seq(TimeSeries(name = name, externalId = Some(name)))
+        Seq(TimeSeries(name = name, externalId = name))
       )
       .head
     try {

--- a/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
@@ -5,9 +5,9 @@ import com.cognite.sdk.scala.common.{DataPointsResourceBehaviors, SdkTest}
 
 class GreenfieldDataPointsTest extends SdkTest with DataPointsResourceBehaviors {
   override def withTimeSeries(testCode: TimeSeries => Any): Unit = {
-    val name = s"data-points-test-${UUID.randomUUID().toString}"
+    val name = Some(s"data-points-test-${UUID.randomUUID().toString}")
     val timeSeries = greenfieldClient.timeSeries.createFromRead(
-      Seq(TimeSeries(name = name, externalId = Some(name)))
+      Seq(TimeSeries(name = name, externalId = name))
     ).head
     try {
       val _ = testCode(timeSeries)

--- a/src/test/scala/com/cognite/sdk/scala/v1/StringDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/StringDataPointsTest.scala
@@ -5,9 +5,9 @@ import com.cognite.sdk.scala.common.{SdkTest, StringDataPointsResourceBehaviors}
 
 class StringDataPointsTest extends SdkTest with StringDataPointsResourceBehaviors {
   override def withStringTimeSeries(testCode: TimeSeries => Any): Unit = {
-    val name = s"string-data-points-test-${UUID.randomUUID().toString}"
+    val name = Some(s"string-data-points-test-${UUID.randomUUID().toString}")
     val timeSeries = client.timeSeries.createFromRead(
-      Seq(TimeSeries(name = name, externalId = Some(name), isString = true))
+      Seq(TimeSeries(name = name, externalId = name, isString = true))
     ).head
     try {
       val _ = testCode(timeSeries)


### PR DESCRIPTION
- made name field optional in time series case classes (except for update, search and filter where it was either already optional or the setter for that field was optional)
- added time series with no name to writable test
- added manual test that we can insert / retrieve / delete data from a time series that doesn't have a name

Fixes #55 