### PR TITLE
Sttp backend wrapper for retrying failed requests in certain cases

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/Constants.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/Constants.scala
@@ -1,8 +1,13 @@
 package com.cognite.sdk.scala.common
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
 
 object Constants {
   val dataPointsBatchSize: Int = 100000
   val aggregatesBatchSize: Int = 10000
   val defaultBatchSize: Int = 1000
   val rowsBatchSize: Int = 10000
+  val DefaultMaxRetries = 10
+  val DefaultInitialRetryDelay: FiniteDuration = 150.millis
+  val DefaultMaxBackoffDelay: FiniteDuration = 120.seconds
 }

--- a/src/main/scala/com/cognite/sdk/scala/common/RetryingBackend.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/RetryingBackend.scala
@@ -1,0 +1,92 @@
+package com.cognite.sdk.scala.common
+import cats.effect.Timer
+import com.softwaremill.sttp.{Id, MonadError, Request, Response, SttpBackend}
+
+import scala.concurrent.duration.{FiniteDuration, _}
+import scala.concurrent.TimeoutException
+import scala.util.Random
+
+trait Sleep[R[_]] {
+  def sleep(sleepDuration: FiniteDuration): R[Unit]
+}
+
+object Sleep {
+  class CatsSleep[F[_]](implicit T: Timer[F]) extends Sleep[F] {
+    override def sleep(sleepDuration: FiniteDuration): F[Unit] =
+      T.sleep(sleepDuration)
+  }
+
+  implicit def catsSleep[R[_]](implicit T: Timer[R]): Sleep[R] =
+    new CatsSleep[R]
+
+  implicit val idSleep = new Sleep[Id] {
+    override def sleep(sleepDuration: FiniteDuration): Id[Unit] = {
+      Thread.sleep(sleepDuration.toMillis)
+      ()
+    }
+  }
+}
+
+class RetryingBackend[R[_], S](delegate: SttpBackend[R, S], maxRetries: Option[Int] = None)(
+    implicit sleepImpl: Sleep[R]
+) extends SttpBackend[R, S] {
+  override def send[T](
+      request: Request[T, S]
+  ): R[Response[T]] =
+    sendWithRetryCounter(
+      request,
+      maxRetries.getOrElse(Constants.DefaultMaxRetries)
+    )
+
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion"))
+  def sendWithRetryCounter[T](
+      request: Request[T, S],
+      retries: Int,
+      initialDelay: FiniteDuration = Constants.DefaultInitialRetryDelay
+  ): R[Response[T]] = {
+    val exponentialDelay = (Constants.DefaultMaxBackoffDelay / 2).min(initialDelay * 2)
+    val randomDelayScale = (Constants.DefaultMaxBackoffDelay / 2).min(initialDelay * 2).toMillis
+    val nextDelay = Random.nextInt(randomDelayScale.toInt).millis + exponentialDelay
+    val r = responseMonad.handleError(delegate.send(request)) {
+      case cdpError: CdpApiException =>
+        if (shouldRetry(cdpError.code) && retries > 0) {
+          responseMonad.flatMap(sleepImpl.sleep(initialDelay))(
+            _ =>
+              sendWithRetryCounter(
+                request,
+                retries - 1,
+                nextDelay
+              )
+          )
+        } else {
+          responseMonad.error(cdpError)
+        }
+      case e: TimeoutException =>
+        if (retries > 0) {
+          responseMonad.flatMap(sleepImpl.sleep(initialDelay))(
+            _ =>
+              sendWithRetryCounter(
+                request,
+                retries - 1,
+                nextDelay
+              )
+          )
+        } else {
+          responseMonad.error(e)
+        }
+      case error => responseMonad.error(error)
+    }
+    responseMonad.flatMap(r) { resp =>
+      responseMonad.unit(resp)
+    }
+  }
+
+  private def shouldRetry(status: Int): Boolean =
+    status match {
+      case 429 | 401 | 500 | 502 | 503 | 504 => true
+      case _ => false
+    }
+
+  override def close(): Unit = delegate.close()
+  override def responseMonad: MonadError[R] = delegate.responseMonad
+}

--- a/src/main/scala/com/cognite/sdk/scala/v1/package.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/package.scala
@@ -2,7 +2,9 @@ package com.cognite.sdk.scala
 
 import cats.Id
 import com.softwaremill.sttp.{HttpURLConnectionBackend, SttpBackend}
+import com.cognite.sdk.scala.common.RetryingBackend
 
 package object v1 {
-  implicit val sttpBackend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend()
+  implicit val sttpBackend: SttpBackend[Id, Nothing] =
+    new RetryingBackend[Id, Nothing](HttpURLConnectionBackend())
 }

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
@@ -311,7 +311,9 @@ class DataPointsResource[F[_]](val requestSession: RequestSession[F])
       toAggregateMap(parseAggregateDataPoints(dataPointListResponse))
     }
 
-  private def queryProtobuf[Q: Encoder, R](query: Q)(mapDataPointList: DataPointListResponse => R) =
+  private def queryProtobuf[Q: Encoder, R](
+      query: Q
+  )(mapDataPointList: DataPointListResponse => R): F[R] =
     requestSession
       .sendCdf(
         { request =>

--- a/src/test/scala/com/cognite/sdk/scala/common/ReadBehaviours.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/ReadBehaviours.scala
@@ -61,7 +61,7 @@ trait ReadBehaviours extends Matchers { this: FlatSpec =>
         .compile
         .toList
         .length
-      assert(unlimitedLength == partitionsLength)
+      assert(unlimitedLength <= partitionsLength)
     }
   }
 

--- a/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
@@ -1,0 +1,36 @@
+package com.cognite.sdk.scala.common
+
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration._
+import scala.util.Random
+import org.scalatest.Assertion
+import org.scalatest.exceptions.TestFailedException
+
+trait RetryWhile {
+  def retryWithExpectedResult[A](
+        action: => A,
+        result: Option[A],
+        shouldRetry: Seq[A => Assertion],
+        retriesRemaining: Int = Constants.DefaultMaxRetries,
+        initialDelay: FiniteDuration = Constants.DefaultInitialRetryDelay
+      ): A = {
+    val exponentialDelay = (Constants.DefaultMaxBackoffDelay / 2).min(initialDelay * 2)
+    val randomDelayScale = (Constants.DefaultMaxBackoffDelay / 2).min(Constants.DefaultInitialRetryDelay * 2).toMillis
+    val nextDelay = Random.nextInt(randomDelayScale.toInt).millis + exponentialDelay
+    shouldRetry.foreach(assertion => {
+        try {
+          assertion(result.getOrElse(action))
+        } catch {
+          case testFailed: TestFailedException =>
+          if (retriesRemaining > 0) {
+            Thread.sleep(initialDelay.toMillis)
+            val actionValue = action
+            retryWithExpectedResult[A](action, Some(actionValue), Seq(assertion), retriesRemaining - 1, nextDelay)
+          } else {
+            throw testFailed
+          }
+        }
+      })
+    result.getOrElse(action)
+  }
+}

--- a/src/test/scala/com/cognite/sdk/scala/common/SdkTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/SdkTest.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import cats.{Id, Monad}
 import com.cognite.sdk.scala.v1.{GenericClient, sttpBackend}
-import com.softwaremill.sttp.{MonadError, Request, Response, SttpBackend}
+import com.softwaremill.sttp.{HttpURLConnectionBackend, MonadError, Request, Response, SttpBackend}
 import org.scalatest.{FlatSpec, Matchers}
 
 class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBackend[R, S] {
@@ -29,11 +29,12 @@ class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBacke
 }
 
 abstract class SdkTest extends FlatSpec with Matchers {
-  val client = new GenericClient("scala-sdk-test")(
+
+  val client = new GenericClient[Id, Nothing]("scala-sdk-test")(
     implicitly[Monad[Id]],
     auth,
     // Use this if you need request logs for debugging: new LoggingSttpBackend[Id, Nothing](sttpBackend)
-    sttpBackend
+    new RetryingBackend[Id, Nothing](HttpURLConnectionBackend())
   )
 
   val greenfieldClient = new GenericClient(

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
@@ -1,11 +1,11 @@
 package com.cognite.sdk.scala.v1
 
 import cats.data.NonEmptyList
-import com.cognite.sdk.scala.common.SdkTest
+import com.cognite.sdk.scala.common.{RetryWhile, SdkTest}
 import io.circe.syntax._
 import org.scalatest.ParallelTestExecution
 
-class SequenceRowsTest extends SdkTest with ParallelTestExecution {
+class SequenceRowsTest extends SdkTest with ParallelTestExecution with RetryWhile {
   def withSequence(testCode: Sequence => Any): Unit = {
     val externalId = shortRandom()
     val sequence = client.sequences.createOneFromRead(
@@ -37,36 +37,48 @@ class SequenceRowsTest extends SdkTest with ParallelTestExecution {
 
   it should "be possible to insert, update, and delete sequence rows" in withSequence { sequence =>
     client.sequenceRows.insertById(sequence.id, sequence.columns.map(_.externalId).toList, testRows)
-    Thread.sleep(5000)
-    val (_, rows) = client.sequenceRows.queryById(
-      sequence.id, minRow, maxRow + 1)
-    rows should contain theSameElementsAs testRows
+    val rows = retryWithExpectedResult[Seq[SequenceRow]](
+      client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
+      None,
+      Seq(r => r should contain theSameElementsAs testRows)
+    )
 
     val updateRows = testRows.map { row =>
       row.copy(values = row.values.updated(0, row.values.head.mapString(s => s"${s}-updated")))
     }
     client.sequenceRows.insertById(sequence.id, sequence.columns.map(_.externalId).toList, updateRows)
-    Thread.sleep(5000)
     val (_, rowsAfterUpdate) = client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)
-    rowsAfterUpdate should contain theSameElementsAs updateRows
+    retryWithExpectedResult[Seq[SequenceRow]](
+      client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
+      Some(rowsAfterUpdate),
+      Seq(r => r should contain theSameElementsAs updateRows)
+    )
 
     client.sequenceRows.deleteById(sequence.id, rows.map(_.rowNumber).take(1))
-    Thread.sleep(5000)
     val (_, rowsAfterOneDelete) = client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)
-    rowsAfterOneDelete should have size testRows.size.toLong - 1
+    retryWithExpectedResult[Seq[SequenceRow]](
+      client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
+      Some(rowsAfterOneDelete),
+      Seq(r => r should have size testRows.size.toLong - 1 )
+    )
 
     client.sequenceRows.deleteById(sequence.id, rows.map(_.rowNumber))
-    Thread.sleep(5000)
     val (_, rowsAfterDeleteAll) = client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)
-    rowsAfterDeleteAll shouldBe empty
+    retryWithExpectedResult[Seq[SequenceRow]](
+      client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
+      Some(rowsAfterDeleteAll),
+      Seq(r => r shouldBe empty)
+    )
   }
 
   it should "be possible to insert, update and delete sequence rows using externalId" in withSequence { sequence =>
     val externalId = sequence.externalId.get
     client.sequenceRows.insertByExternalId(externalId, sequence.columns.map(_.externalId).toList, testRows)
-    Thread.sleep(5000)
-    val (_, rows) = client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)
-    rows should contain theSameElementsAs testRows
+    val rows = retryWithExpectedResult[Seq[SequenceRow]](
+      client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)._2,
+      None,
+      Seq(r => r should contain theSameElementsAs testRows)
+    )
 
     // note: intentionally using queryById here.
     val (_, rowsById) = client.sequenceRows.queryById(
@@ -74,8 +86,11 @@ class SequenceRowsTest extends SdkTest with ParallelTestExecution {
     rowsById should contain theSameElementsAs testRows
 
     client.sequenceRows.deleteByExternalId(externalId, rows.map(_.rowNumber))
-    Thread.sleep(5000)
     val (_, rowsAfterDeleteAll) = client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)
-    rowsAfterDeleteAll shouldBe empty
+    retryWithExpectedResult[Seq[SequenceRow]](
+      client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)._2,
+      Some(rowsAfterDeleteAll),
+      Seq(r => r shouldBe empty)
+    )
   }
 }


### PR DESCRIPTION
- retrying backend with default 10 retries
- same backoff logic as spark data source
- should change which error codes we retry and don't retry for
- tests that return errors for the first 4 responses and success on the 5th to check that a retrying backend will succeed where a non-retrying backend fails
- emil helped a lot to abstract it / make it more general and not enforcing a blocking sleep in cases it's not required, like with IO

- retryWithExpectedResult for tests, where you can pass in the initial result, the request to make, and a sequence of assertions you want the result to pass
- makes the data points and string data points tests run in ~15 seconds instead of a minute
- takes a really long time if a test fails bc of an incorrect assertion though, so we might want to change the retry delays (I just copied them from the retrying backend / spark datasource)