### PR TITLE
Support updates by externalId

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
@@ -30,13 +30,14 @@ final case class AssetCreate(
 ) extends WithExternalId
 
 final case class AssetUpdate(
-    id: Long,
     name: Option[NonNullableSetter[String]] = None,
     description: Option[Setter[String]] = None,
     source: Option[Setter[String]] = None,
     externalId: Option[Setter[String]] = None,
-    metadata: Option[NonNullableSetter[Map[String, String]]] = None
-) extends WithId[Long]
+    metadata: Option[NonNullableSetter[Map[String, String]]] = None,
+    parentId: Option[Setter[Long]] = None,
+    parentExternalId: Option[Setter[String]] = None
+)
 
 final case class AssetsFilter(
     name: Option[String] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/events.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/events.scala
@@ -33,7 +33,6 @@ final case class EventCreate(
 ) extends WithExternalId
 
 final case class EventUpdate(
-    id: Long = 0,
     startTime: Option[Setter[Instant]] = None,
     endTime: Option[Setter[Instant]] = None,
     description: Option[Setter[String]] = None,
@@ -43,7 +42,7 @@ final case class EventUpdate(
     assetIds: Option[NonNullableSetter[Seq[Long]]] = None,
     source: Option[Setter[String]] = None,
     externalId: Option[Setter[String]] = None
-) extends WithId[Long]
+)
 
 final case class EventsFilter(
     startTime: Option[TimeRange] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/files.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/files.scala
@@ -30,12 +30,11 @@ final case class FileCreate(
 )
 
 final case class FileUpdate(
-    id: Long = 0,
     externalId: Option[Setter[String]] = None,
     source: Option[Setter[String]] = None,
     metadata: Option[NonNullableSetter[Map[String, String]]] = None,
     assetIds: Option[NonNullableSetter[Seq[Long]]] = None
-) extends WithId[Long]
+)
 
 final case class FilesFilter(
     name: Option[String] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/assets.scala
@@ -16,7 +16,8 @@ class Assets[F[_]](val requestSession: RequestSession[F])
     with DeleteByExternalIdsWithIgnoreUnknownIds[F]
     with PartitionedFilter[Asset, AssetsFilter, F]
     with Search[Asset, AssetsQuery, F]
-    with Update[Asset, AssetUpdate, F] {
+    with UpdateById[Asset, AssetUpdate, F]
+    with UpdateByExternalId[Asset, AssetUpdate, F] {
   import Assets._
   override val baseUri = uri"${requestSession.baseUri}/assets"
 
@@ -43,8 +44,15 @@ class Assets[F[_]](val requestSession: RequestSession[F])
   override def createItems(items: Items[AssetCreate]): F[Seq[Asset]] =
     Create.createItems[F, Asset, AssetCreate](requestSession, baseUri, items)
 
-  override def update(items: Seq[AssetUpdate]): F[Seq[Asset]] =
-    Update.update[F, Asset, AssetUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, AssetUpdate]): F[Seq[Asset]] =
+    UpdateById.updateById[F, Asset, AssetUpdate](requestSession, baseUri, items)
+
+  override def updateByExternalId(items: Map[String, AssetUpdate]): F[Seq[Asset]] =
+    UpdateByExternalId.updateByExternalId[F, Asset, AssetUpdate](
+      requestSession,
+      baseUri,
+      items
+    )
 
   override def deleteByIds(ids: Seq[Long]): F[Unit] = deleteByIds(ids, false)
 
@@ -116,10 +124,7 @@ object Assets {
   implicit val createAssetEncoder: Encoder[AssetCreate] = deriveEncoder[AssetCreate]
   implicit val createAssetsItemsEncoder: Encoder[Items[AssetCreate]] =
     deriveEncoder[Items[AssetCreate]]
-  implicit val assetUpdateEncoder: Encoder[AssetUpdate] =
-    deriveEncoder[AssetUpdate]
-  implicit val updateAssetsItemsEncoder: Encoder[Items[AssetUpdate]] =
-    deriveEncoder[Items[AssetUpdate]]
+  implicit val assetUpdateEncoder: Encoder[AssetUpdate] = deriveEncoder[AssetUpdate]
   implicit val assetsFilterEncoder: Encoder[AssetsFilter] =
     deriveEncoder[AssetsFilter]
   implicit val assetsSearchEncoder: Encoder[AssetsSearch] =

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/events.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/events.scala
@@ -16,7 +16,8 @@ class Events[F[_]](val requestSession: RequestSession[F])
     with DeleteByExternalIdsWithIgnoreUnknownIds[F]
     with PartitionedFilter[Event, EventsFilter, F]
     with Search[Event, EventsQuery, F]
-    with Update[Event, EventUpdate, F] {
+    with UpdateById[Event, EventUpdate, F]
+    with UpdateByExternalId[Event, EventUpdate, F] {
   import Events._
   override val baseUri = uri"${requestSession.baseUri}/events"
 
@@ -43,8 +44,11 @@ class Events[F[_]](val requestSession: RequestSession[F])
   override def createItems(items: Items[EventCreate]): F[Seq[Event]] =
     Create.createItems[F, Event, EventCreate](requestSession, baseUri, items)
 
-  override def update(items: Seq[EventUpdate]): F[Seq[Event]] =
-    Update.update[F, Event, EventUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, EventUpdate]): F[Seq[Event]] =
+    UpdateById.updateById[F, Event, EventUpdate](requestSession, baseUri, items)
+
+  override def updateByExternalId(items: Map[String, EventUpdate]): F[Seq[Event]] =
+    UpdateByExternalId.updateByExternalId[F, Event, EventUpdate](requestSession, baseUri, items)
 
   override def deleteByIds(ids: Seq[Long]): F[Unit] = deleteByIds(ids, false)
 

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/files.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/files.scala
@@ -20,7 +20,8 @@ class Files[F[_]](val requestSession: RequestSession[F])
     with DeleteByExternalIds[F]
     with Filter[File, FilesFilter, F]
     with Search[File, FilesQuery, F]
-    with Update[File, FileUpdate, F] {
+    with UpdateById[File, FileUpdate, F]
+    with UpdateByExternalId[File, FileUpdate, F] {
   import Files._
   override val baseUri = uri"${requestSession.baseUri}/files"
 
@@ -96,8 +97,11 @@ class Files[F[_]](val requestSession: RequestSession[F])
   override def retrieveByExternalIds(externalIds: Seq[String]): F[Seq[File]] =
     RetrieveByExternalIds.retrieveByExternalIds(requestSession, baseUri, externalIds)
 
-  override def update(items: Seq[FileUpdate]): F[Seq[File]] =
-    Update.update[F, File, FileUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, FileUpdate]): F[Seq[File]] =
+    UpdateById.updateById[F, File, FileUpdate](requestSession, baseUri, items)
+
+  override def updateByExternalId(items: Map[String, FileUpdate]): F[Seq[File]] =
+    UpdateByExternalId.updateByExternalId[F, File, FileUpdate](requestSession, baseUri, items)
 
   override def deleteByIds(ids: Seq[Long]): F[Unit] =
     DeleteByIds.deleteByIds(requestSession, baseUri, ids)

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/sequences.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/sequences.scala
@@ -14,7 +14,8 @@ class SequencesResource[F[_]](val requestSession: RequestSession[F])
     with DeleteByIds[F, Long]
     with DeleteByExternalIds[F]
     with Search[Sequence, SequenceQuery, F]
-    with Update[Sequence, SequenceUpdate, F] {
+    with UpdateById[Sequence, SequenceUpdate, F]
+    with UpdateByExternalId[Sequence, SequenceUpdate, F] {
   import SequencesResource._
 
   override val baseUri = uri"${requestSession.baseUri}/sequences"
@@ -42,8 +43,15 @@ class SequencesResource[F[_]](val requestSession: RequestSession[F])
   override def createItems(items: Items[SequenceCreate]): F[Seq[Sequence]] =
     Create.createItems[F, Sequence, SequenceCreate](requestSession, baseUri, items)
 
-  override def update(items: Seq[SequenceUpdate]): F[Seq[Sequence]] =
-    Update.update[F, Sequence, SequenceUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, SequenceUpdate]): F[Seq[Sequence]] =
+    UpdateById.updateById[F, Sequence, SequenceUpdate](requestSession, baseUri, items)
+
+  override def updateByExternalId(items: Map[String, SequenceUpdate]): F[Seq[Sequence]] =
+    UpdateByExternalId.updateByExternalId[F, Sequence, SequenceUpdate](
+      requestSession,
+      baseUri,
+      items
+    )
 
   override def deleteByIds(ids: Seq[Long]): F[Unit] =
     DeleteByIds.deleteByIds(requestSession, baseUri, ids)

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/threeD.scala
@@ -12,7 +12,7 @@ class ThreeDModels[F[_]](val requestSession: RequestSession[F])
     with RetrieveByIds[ThreeDModel, F]
     with Readable[ThreeDModel, F]
     with DeleteByIds[F, Long]
-    with Update[ThreeDModel, ThreeDModelUpdate, F]
+    with UpdateById[ThreeDModel, ThreeDModelUpdate, F]
     with WithRequestSession[F] {
   import ThreeDModels._
   override val baseUri = uri"${requestSession.baseUri}/3d/models"
@@ -56,8 +56,8 @@ class ThreeDModels[F[_]](val requestSession: RequestSession[F])
   override def createItems(items: Items[ThreeDModelCreate]): F[Seq[ThreeDModel]] =
     Create.createItems[F, ThreeDModel, ThreeDModelCreate](requestSession, baseUri, items)
 
-  override def update(items: Seq[ThreeDModelUpdate]): F[Seq[ThreeDModel]] =
-    Update.update[F, ThreeDModel, ThreeDModelUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, ThreeDModelUpdate]): F[Seq[ThreeDModel]] =
+    UpdateById.updateById[F, ThreeDModel, ThreeDModelUpdate](requestSession, baseUri, items)
 }
 
 object ThreeDModels {
@@ -151,7 +151,7 @@ class ThreeDRevisions[F[_]](val requestSession: RequestSession[F], modelId: Long
     with RetrieveByIds[ThreeDRevision, F]
     with Readable[ThreeDRevision, F]
     with DeleteByIds[F, Long]
-    with Update[ThreeDRevision, ThreeDRevisionUpdate, F]
+    with UpdateById[ThreeDRevision, ThreeDRevisionUpdate, F]
     with WithRequestSession[F] {
   import ThreeDRevisions._
   override val baseUri =
@@ -196,8 +196,8 @@ class ThreeDRevisions[F[_]](val requestSession: RequestSession[F], modelId: Long
   override def createItems(items: Items[ThreeDRevisionCreate]): F[Seq[ThreeDRevision]] =
     Create.createItems[F, ThreeDRevision, ThreeDRevisionCreate](requestSession, baseUri, items)
 
-  override def update(items: Seq[ThreeDRevisionUpdate]): F[Seq[ThreeDRevision]] =
-    Update.update[F, ThreeDRevision, ThreeDRevisionUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, ThreeDRevisionUpdate]): F[Seq[ThreeDRevision]] =
+    UpdateById.updateById[F, ThreeDRevision, ThreeDRevisionUpdate](requestSession, baseUri, items)
 }
 
 object ThreeDRevisions {

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/timeSeries.scala
@@ -16,7 +16,8 @@ class TimeSeriesResource[F[_]](val requestSession: RequestSession[F])
     with DeleteByExternalIds[F]
     with PartitionedFilter[TimeSeries, TimeSeriesFilter, F]
     with Search[TimeSeries, TimeSeriesQuery, F]
-    with Update[TimeSeries, TimeSeriesUpdate, F] {
+    with UpdateById[TimeSeries, TimeSeriesUpdate, F]
+    with UpdateByExternalId[TimeSeries, TimeSeriesUpdate, F] {
   import TimeSeriesResource._
   override val baseUri = uri"${requestSession.baseUri}/timeseries"
 
@@ -43,8 +44,15 @@ class TimeSeriesResource[F[_]](val requestSession: RequestSession[F])
   override def createItems(items: Items[TimeSeriesCreate]): F[Seq[TimeSeries]] =
     Create.createItems[F, TimeSeries, TimeSeriesCreate](requestSession, baseUri, items)
 
-  override def update(items: Seq[TimeSeriesUpdate]): F[Seq[TimeSeries]] =
-    Update.update[F, TimeSeries, TimeSeriesUpdate](requestSession, baseUri, items)
+  override def updateById(items: Map[Long, TimeSeriesUpdate]): F[Seq[TimeSeries]] =
+    UpdateById.updateById[F, TimeSeries, TimeSeriesUpdate](requestSession, baseUri, items)
+
+  override def updateByExternalId(items: Map[String, TimeSeriesUpdate]): F[Seq[TimeSeries]] =
+    UpdateByExternalId.updateByExternalId[F, TimeSeries, TimeSeriesUpdate](
+      requestSession,
+      baseUri,
+      items
+    )
 
   override def deleteByIds(ids: Seq[Long]): F[Unit] =
     DeleteByIds.deleteByIds(requestSession, baseUri, ids)

--- a/src/main/scala/com/cognite/sdk/scala/v1/sequences.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/sequences.scala
@@ -52,13 +52,12 @@ final case class SequenceCreate(
 ) extends WithExternalId
 
 final case class SequenceUpdate(
-    id: Long = 0,
     name: Option[Setter[String]] = None,
     description: Option[Setter[String]] = None,
     assetId: Option[Setter[Long]] = None,
     externalId: Option[Setter[String]] = None,
     metadata: Option[NonNullableSetter[Map[String, String]]] = None
-) extends WithId[Long]
+)
 
 final case class SequenceFilter(
     name: Option[String] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
@@ -34,7 +34,6 @@ final case class TimeSeriesCreate(
 ) extends WithExternalId
 
 final case class TimeSeriesUpdate(
-    id: Long = 0,
     name: Option[Setter[String]] = None,
     externalId: Option[Setter[String]] = None,
     metadata: Option[NonNullableSetter[Map[String, String]]] = None,
@@ -42,7 +41,7 @@ final case class TimeSeriesUpdate(
     assetId: Option[Setter[Long]] = None,
     description: Option[Setter[String]] = None,
     securityCategories: Option[Setter[Seq[Long]]] = None
-) extends WithId[Long]
+)
 
 final case class TimeSeriesSearchFilter(
     name: Option[String] = None,

--- a/src/test/scala/com/cognite/sdk/scala/v1/FilesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/FilesTest.scala
@@ -6,8 +6,7 @@ import java.time.Instant
 import java.util.UUID
 
 import org.scalatest.Matchers
-
-import com.cognite.sdk.scala.common.{CdpApiException, ReadBehaviours, SdkTest, WritableBehaviors}
+import com.cognite.sdk.scala.common.{CdpApiException, ReadBehaviours, SdkTest, SetValue, WritableBehaviors}
 
 class FilesTest extends SdkTest with ReadBehaviours with WritableBehaviors with Matchers {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
@@ -95,6 +94,26 @@ class FilesTest extends SdkTest with ReadBehaviours with WritableBehaviors with 
 
     // delete it
     client.files.deleteByIds(Seq(createdItem.id))
+  }
+
+  it should "allow updates by Id" in {
+    val testFile = File(name = "test-file-1", externalId = Some("test-externalId-1"))
+    val createdItem = client.files.createOneFromRead(testFile)
+    val updatedFile = client.files.updateById(Map(createdItem.id -> FileUpdate(externalId = Some(SetValue("test-externalId-1-1")))))
+    assert(updatedFile.length == 1)
+    assert(createdItem.name == updatedFile.head.name)
+    assert(updatedFile.head.externalId.get == s"${testFile.externalId.get}-1")
+    client.files.deleteByExternalId("test-externalId-1-1")
+  }
+
+  it should "allow updates by externalId" in {
+    val testFile = File(name = "test-file-1", externalId = Some("test-externalId-1"), source = Some("source-1"))
+    val createdItem = client.files.createOneFromRead(testFile)
+    val updatedFile = client.files.updateByExternalId(Map(createdItem.externalId.get -> FileUpdate(source = Some(SetValue("source-1-1")))))
+    assert(updatedFile.length == 1)
+    assert(createdItem.name == updatedFile.head.name)
+    assert(updatedFile.head.source.get == s"${testFile.source.get}-1")
+    client.files.deleteByExternalId("test-externalId-1")
   }
 
   it should "support filter" in {


### PR DESCRIPTION
- updateByExternalId for assets, events, sequences, files & timeseries
- change update to updateById
- directly test updateByExternalId in assetsTest
- directly test updateById in eventsTest
- change Set to SetValue

should find a nicer way to let users directly use updateById and updateByExternalId 
