### PR TITLE
Add WithSetExternalId trait to xyUpdate case classes

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
@@ -72,6 +72,10 @@ trait WithExternalId {
   val externalId: Option[String]
 }
 
+trait WithSetExternalId {
+  val externalId: Option[Setter[String]]
+}
+
 object EitherDecoder {
   def eitherDecoder[A, B](implicit a: Decoder[A], b: Decoder[B]): Decoder[Either[A, B]] = {
     val l: Decoder[Either[A, B]] = a.map(Left.apply)

--- a/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
@@ -1,8 +1,7 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
-import com.cognite.sdk.scala.common.{NonNullableSetter, SearchQuery, Setter, WithExternalId, WithId}
+import com.cognite.sdk.scala.common._
 
 final case class Asset(
     externalId: Option[String] = None,
@@ -37,7 +36,7 @@ final case class AssetUpdate(
     metadata: Option[NonNullableSetter[Map[String, String]]] = None,
     parentId: Option[Setter[Long]] = None,
     parentExternalId: Option[Setter[String]] = None
-)
+) extends WithSetExternalId
 
 final case class AssetsFilter(
     name: Option[String] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/events.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/events.scala
@@ -1,8 +1,7 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
-import com.cognite.sdk.scala.common.{NonNullableSetter, SearchQuery, Setter, WithExternalId, WithId}
+import com.cognite.sdk.scala.common._
 
 final case class Event(
     id: Long = 0,
@@ -42,7 +41,7 @@ final case class EventUpdate(
     assetIds: Option[NonNullableSetter[Seq[Long]]] = None,
     source: Option[Setter[String]] = None,
     externalId: Option[Setter[String]] = None
-)
+) extends WithSetExternalId
 
 final case class EventsFilter(
     startTime: Option[TimeRange] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
@@ -1,8 +1,7 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
-import com.cognite.sdk.scala.common.{NonNullableSetter, SearchQuery, Setter, WithExternalId, WithId}
+import com.cognite.sdk.scala.common._
 
 final case class TimeSeries(
     name: Option[String] = None,
@@ -41,7 +40,7 @@ final case class TimeSeriesUpdate(
     assetId: Option[Setter[Long]] = None,
     description: Option[Setter[String]] = None,
     securityCategories: Option[Setter[Seq[Long]]] = None
-)
+) extends WithSetExternalId
 
 final case class TimeSeriesSearchFilter(
     name: Option[String] = None,


### PR DESCRIPTION
- Make the update case class for assets, events, and timeseries extend `WithSetExternalId`
- Going to use this trait in the spark datasource when transforming from some `xyUpsertSchema` case class to some `xyUpdate` case class.

See https://github.com/cognitedata/cdp-spark-datasource/pull/347