### PR TITLE
Show request id in CdpApiException

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/ReadWritableResource.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/ReadWritableResource.scala
@@ -30,18 +30,11 @@ object DeleteByIds {
       EitherDecoder.eitherDecoder[CdpApiError, Unit]
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(Items(ids.map(CogniteInternalId)))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+    requestSession.post[Unit, Unit, Items[CogniteInternalId]](
+      Items(ids.map(CogniteInternalId)),
+      uri"$baseUri/delete",
+      _ => ()
+    )
   }
 
   def deleteByIdsWithIgnoreUnknownIds[F[_]](
@@ -54,18 +47,11 @@ object DeleteByIds {
       EitherDecoder.eitherDecoder[CdpApiError, Unit]
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(ItemsWithIgnoreUnknownIds(ids.map(CogniteInternalId), ignoreUnknownIds))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+    requestSession.post[Unit, Unit, ItemsWithIgnoreUnknownIds](
+      ItemsWithIgnoreUnknownIds(ids.map(CogniteInternalId), ignoreUnknownIds),
+      uri"$baseUri/delete",
+      _ => ()
+    )
   }
 
 }
@@ -95,20 +81,11 @@ object DeleteByExternalIds {
   ): F[Unit] =
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(
-            ItemsWithIgnoreUnknownIds(externalIds.map(CogniteExternalId), ignoreUnknownIds)
-          )
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+    requestSession.post[Unit, Unit, ItemsWithIgnoreUnknownIds](
+      ItemsWithIgnoreUnknownIds(externalIds.map(CogniteExternalId), ignoreUnknownIds),
+      uri"$baseUri/delete",
+      _ => ()
+    )
 
   def deleteByExternalIds[F[_]](
       requestSession: RequestSession[F],
@@ -117,18 +94,11 @@ object DeleteByExternalIds {
   ): F[Unit] =
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(Items(externalIds.map(CogniteExternalId)))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+    requestSession.post[Unit, Unit, Items[CogniteExternalId]](
+      Items(externalIds.map(CogniteExternalId)),
+      uri"$baseUri/delete",
+      _ => ()
+    )
 }
 
 trait Create[R, W, F[_]] extends WithRequestSession[F] with CreateOne[R, W, F] with BaseUri {
@@ -160,19 +130,11 @@ object Create {
   ): F[Seq[R]] = {
     implicit val errorOrItemsWithCursorDecoder: Decoder[Either[CdpApiError, ItemsWithCursor[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, ItemsWithCursor[R]]
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(baseUri)
-          .body(items)
-          .response(asJson[Either[CdpApiError, ItemsWithCursor[R]]])
-          .mapResponse {
-            case Left(value) =>
-              throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(baseUri)
-            case Right(Right(value)) => value.items
-          }
-      }
+    requestSession.post[Seq[R], ItemsWithCursor[R], Items[W]](
+      items,
+      baseUri,
+      value => value.items
+    )
   }
 }
 
@@ -192,18 +154,10 @@ object CreateOne {
   ): F[R] = {
     implicit val errorOrItemsWithCursorDecoder: Decoder[Either[CdpApiError, R]] =
       EitherDecoder.eitherDecoder[CdpApiError, R]
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(baseUri)
-          .body(item)
-          .response(asJson[Either[CdpApiError, R]])
-          .mapResponse {
-            case Left(value) =>
-              throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(baseUri)
-            case Right(Right(value)) => value
-          }
-      }
+    requestSession.post[R, R, W](
+      item,
+      baseUri,
+      value => value
+    )
   }
 }

--- a/src/main/scala/com/cognite/sdk/scala/common/ReadableResource.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/ReadableResource.scala
@@ -103,18 +103,10 @@ object Readable {
       uriWithCursor.param("partition", p.toString)
     }
 
-    requestSession
-      .sendCdf { request =>
-        request
-          .get(uriWithCursorAndPartition)
-          .response(asJson[Either[CdpApiError, ItemsWithCursor[R]]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) =>
-              throw cdpApiError.asException(uriWithCursorAndPartition)
-            case Right(Right(value)) => value
-          }
-      }
+    requestSession.get[ItemsWithCursor[R], ItemsWithCursor[R]](
+      uriWithCursorAndPartition,
+      value => value
+    )
   }
 }
 
@@ -130,18 +122,11 @@ object RetrieveByIds {
   ): F[Seq[R]] = {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/byids")
-          .body(Items(ids.map(CogniteInternalId)))
-          .response(asJson[Either[CdpApiError, Items[R]]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/byids")
-            case Right(Right(value)) => value.items
-          }
-      }
+    requestSession.post[Seq[R], Items[R], Items[CogniteInternalId]](
+      Items(ids.map(CogniteInternalId)),
+      uri"$baseUri/byids",
+      value => value.items
+    )
   }
 }
 
@@ -161,17 +146,10 @@ object RetrieveByExternalIds {
   ): F[Seq[R]] = {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
-    requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/byids")
-          .body(Items(externalIds.map(CogniteExternalId)))
-          .response(asJson[Either[CdpApiError, Items[R]]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/byids")
-            case Right(Right(value)) => value.items
-          }
-      }
+    requestSession.post[Seq[R], Items[R], Items[CogniteExternalId]](
+      Items(externalIds.map(CogniteExternalId)),
+      uri"$baseUri/byids",
+      value => value.items
+    )
   }
 }

--- a/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
@@ -21,10 +21,11 @@ final case class CdpApiErrorPayload(
     missingFields: Option[Seq[String]]
 )
 final case class CdpApiError(error: CdpApiErrorPayload) {
-  def asException(url: Uri): CdpApiException =
+  def asException(url: Uri, requestId: Option[String]): CdpApiException =
     this.error
       .into[CdpApiException]
       .withFieldConst(_.url, url)
+      .withFieldConst(_.requestId, requestId)
       .transform
 }
 object CdpApiError {
@@ -37,8 +38,12 @@ final case class CdpApiException(
     message: String,
     missing: Option[Seq[JsonObject]],
     duplicated: Option[Seq[JsonObject]],
-    missingFields: Option[Seq[String]]
-) extends Throwable(s"Request to ${url.toString()} failed with status ${code.toString}: $message")
+    missingFields: Option[Seq[String]],
+    requestId: Option[String]
+) extends Throwable(
+      s"Request ${requestId.map(id => s"with id $id").getOrElse("")} to ${url
+        .toString()} failed with status ${code.toString}: $message"
+    )
 
 final case class DataPoint(
     timestamp: Instant,

--- a/src/main/scala/com/cognite/sdk/scala/common/search.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/search.scala
@@ -23,17 +23,10 @@ object Search {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/search")
-          .body(searchQuery)
-          .response(asJson[Either[CdpApiError, Items[R]]])
-          .mapResponse {
-            case Left(value) =>
-              throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/search")
-            case Right(Right(value)) => value.items
-          }
-      }
+      .post[Seq[R], Items[R], Q](
+        searchQuery,
+        uri"$baseUri/search",
+        value => value.items
+      )
   }
 }

--- a/src/main/scala/com/cognite/sdk/scala/common/update.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/update.scala
@@ -58,21 +58,14 @@ object UpdateById {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/update")
-          .body(Items(updates.map {
-            case (id, update) =>
-              UpdateRequest(update.asJson, id)
-          }.toSeq))
-          .response(asJson[Either[CdpApiError, Items[R]]])
-          .mapResponse {
-            case Left(value) =>
-              throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/update")
-            case Right(Right(value)) => value.items
-          }
-      }
+      .post[Seq[R], Items[R], Items[UpdateRequest]](
+        Items(updates.map {
+          case (id, update) =>
+            UpdateRequest(update.asJson, id)
+        }.toSeq),
+        uri"$baseUri/update",
+        value => value.items
+      )
   }
 }
 
@@ -108,20 +101,13 @@ object UpdateByExternalId {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/update")
-          .body(Items(updates.map {
-            case (id, update) =>
-              UpdateRequestExternalId(update.asJson, id)
-          }.toSeq))
-          .response(asJson[Either[CdpApiError, Items[R]]])
-          .mapResponse {
-            case Left(value) =>
-              throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/update")
-            case Right(Right(value)) => value.items
-          }
-      }
+      .post[Seq[R], Items[R], Items[UpdateRequestExternalId]](
+        Items(updates.map {
+          case (id, update) =>
+            UpdateRequestExternalId(update.asJson, id)
+        }.toSeq),
+        uri"$baseUri/update",
+        value => value.items
+      )
   }
 }

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/sequenceRows.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/sequenceRows.scala
@@ -21,17 +21,11 @@ class SequenceRows[F[_]](val requestSession: RequestSession[F])
 
   def insertById(id: Long, columns: Seq[String], rows: Seq[SequenceRow]): F[Unit] =
     requestSession
-      .sendCdf { request =>
-        request
-          .post(baseUri)
-          .body(Items(Seq(SequenceRowsInsertById(id, columns, rows))))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(baseUri)
-            case Right(Right(_)) => ()
-          }
-      }
+      .post[Unit, Unit, Items[SequenceRowsInsertById]](
+        Items(Seq(SequenceRowsInsertById(id, columns, rows))),
+        baseUri,
+        _ => ()
+      )
 
   def insertByExternalId(
       externalId: String,
@@ -39,49 +33,27 @@ class SequenceRows[F[_]](val requestSession: RequestSession[F])
       rows: Seq[SequenceRow]
   ): F[Unit] =
     requestSession
-      .sendCdf { request =>
-        request
-          .post(baseUri)
-          .body(
-            Items(
-              Seq(SequenceRowsInsertByExternalId(externalId, columns, rows))
-            )
-          )
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(baseUri)
-            case Right(Right(_)) => ()
-          }
-      }
+      .post[Unit, Unit, Items[SequenceRowsInsertByExternalId]](
+        Items(Seq(SequenceRowsInsertByExternalId(externalId, columns, rows))),
+        baseUri,
+        _ => ()
+      )
 
   def deleteById(id: Long, rows: Seq[Long]): F[Unit] =
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(Items(Seq(SequenceRowsDeleteById(id, rows))))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+      .post[Unit, Unit, Items[SequenceRowsDeleteById]](
+        Items(Seq(SequenceRowsDeleteById(id, rows))),
+        uri"$baseUri/delete",
+        _ => ()
+      )
 
   def deleteByExternalId(externalId: String, rows: Seq[Long]): F[Unit] =
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(Items(Seq(SequenceRowsDeleteByExternalId(externalId, rows))))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+      .post[Unit, Unit, Items[SequenceRowsDeleteByExternalId]](
+        Items(Seq(SequenceRowsDeleteByExternalId(externalId, rows))),
+        uri"$baseUri/delete",
+        _ => ()
+      )
 
   def queryById(
       id: Long,
@@ -91,17 +63,11 @@ class SequenceRows[F[_]](val requestSession: RequestSession[F])
       columns: Option[Seq[String]] = None
   ): F[(Seq[SequenceColumnId], Seq[SequenceRow])] =
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/list")
-          .body(SequenceRowsQueryById(id, inclusiveStart, exclusiveEnd, limit, columns))
-          .response(asJson[Either[CdpApiError, SequenceRowsResponse]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/list")
-            case Right(Right(value)) => (value.columns.toList, value.rows)
-          }
-      }
+      .post[(Seq[SequenceColumnId], Seq[SequenceRow]), SequenceRowsResponse, SequenceRowsQueryById](
+        SequenceRowsQueryById(id, inclusiveStart, exclusiveEnd, limit, columns),
+        uri"$baseUri/list",
+        value => (value.columns.toList, value.rows)
+      )
 
   def queryByExternalId(
       externalId: String,
@@ -111,25 +77,22 @@ class SequenceRows[F[_]](val requestSession: RequestSession[F])
       columns: Option[Seq[String]] = None
   ): F[(Seq[SequenceColumnId], Seq[SequenceRow])] =
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/list")
-          .body(
-            SequenceRowsQueryByExternalId(
-              externalId,
-              inclusiveStart,
-              exclusiveEnd,
-              limit,
-              columns
-            )
-          )
-          .response(asJson[Either[CdpApiError, SequenceRowsResponse]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/list")
-            case Right(Right(value)) => (value.columns.toList, value.rows)
-          }
-      }
+      .post[
+        (Seq[SequenceColumnId], Seq[SequenceRow]),
+        SequenceRowsResponse,
+        SequenceRowsQueryByExternalId
+      ](
+        SequenceRowsQueryByExternalId(
+          externalId,
+          inclusiveStart,
+          exclusiveEnd,
+          limit,
+          columns
+        ),
+        uri"$baseUri/list",
+        value => (value.columns.toList, value.rows)
+      )
+
 }
 
 object SequenceRows {

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/threeD.scala
@@ -23,17 +23,11 @@ class ThreeDModels[F[_]](val requestSession: RequestSession[F])
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(Items(ids.map(CogniteInternalId)))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+      .post[Unit, Unit, Items[CogniteInternalId]](
+        Items(ids.map(CogniteInternalId)),
+        uri"$baseUri/delete",
+        _ => ()
+      )
   }
 
   override private[sdk] def readWithCursor(
@@ -163,17 +157,11 @@ class ThreeDRevisions[F[_]](val requestSession: RequestSession[F], modelId: Long
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
     requestSession
-      .sendCdf { request =>
-        request
-          .post(uri"$baseUri/delete")
-          .body(Items(ids.map(CogniteInternalId)))
-          .response(asJson[Either[CdpApiError, Unit]])
-          .mapResponse {
-            case Left(value) => throw value.error
-            case Right(Left(cdpApiError)) => throw cdpApiError.asException(uri"$baseUri/delete")
-            case Right(Right(_)) => ()
-          }
-      }
+      .post[Unit, Unit, Items[CogniteInternalId]](
+        Items(ids.map(CogniteInternalId)),
+        uri"$baseUri/delete",
+        _ => ()
+      )
   }
 
   override private[sdk] def readWithCursor(

--- a/src/test/scala/com/cognite/sdk/scala/common/WritableBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/WritableBehaviors.scala
@@ -43,6 +43,13 @@ trait WritableBehaviors extends Matchers { this: FlatSpec =>
       }
     }
 
+    it should "include the request id in all cdp api exceptions" in {
+      val caught = intercept[CdpApiException](
+        writable.deleteByIds(idsThatDoNotExist)
+      )
+      assert(caught.requestId.isDefined)
+    }
+
     it should "create and delete items using the read class" in {
       // create a single item
       val createdItem = writable.createFromRead(readExamples.take(1))


### PR DESCRIPTION
-- add request id to error message for all cdp api exceptions
-- add test in WritableBehaviors to verify that some id is there
-- refactor all the individual .sendCdf() calls into .post() or .get() calls in client
-- calls that either send or receive protobuf are not included. They had to be handled separately because we were getting a lot of 500 errors when using the .post() method in client bc of some serialization issue. Should investigate in the future (I added a jira issue to scala sdk)

[DT-1195]

[DT-1195]: https://cognitedata.atlassian.net/browse/DT-1195