### PR TITLE
Add filtering by assetSubtreeIds to Assets

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
@@ -42,6 +42,7 @@ final case class AssetsFilter(
     name: Option[String] = None,
     parentIds: Option[Seq[Long]] = None,
     rootIds: Option[Seq[CogniteId]] = None,
+    assetSubtreeIds: Option[Seq[CogniteId]] = None,
     metadata: Option[Map[String, String]] = None,
     source: Option[String] = None,
     createdTime: Option[TimeRange] = None,

--- a/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
@@ -163,6 +163,15 @@ class AssetsTest extends SdkTest with ReadBehaviours with WritableBehaviors with
       None,
       Seq(a => a should have size 1106)
     )
+
+    val assetSubtreeIdsFilterResult = client.assets
+      .filter(
+        AssetsFilter(
+          assetSubtreeIds = Some(Seq(CogniteInternalId(3028597755787717L))))
+      )
+      .compile
+      .toList
+    assert(assetSubtreeIdsFilterResult.length == 5)
   }
 
   it should "support asset aggregates" in {
@@ -217,7 +226,7 @@ class AssetsTest extends SdkTest with ReadBehaviours with WritableBehaviors with
           search = Some(AssetsSearch(name = Some("ESDV")))
         )
       )
-    assert(esdvResults.length == 15)
+    assert(esdvResults.length == 20)
     val esdvLimitResults = client.assets
       .search(
         AssetsQuery(


### PR DESCRIPTION
This will be useful when developing Asset ingest for Spark Data Source and Jetfire.