### PR TITLE
[DT-1287] Handle responses with unknown content types more gracefully

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
@@ -21,18 +21,24 @@ final case class ItemsWithRecursiveAndIgnoreUnknownIds(
 final case class SdkException(
     message: String,
     uri: Option[Uri] = None,
-    requestId: Option[String] = None
+    requestId: Option[String] = None,
+    responseCode: Option[Int] = None
 ) extends Throwable(message) {
   override def toString: String = {
-    val uriMessage = uri.map(u => s", in response to request sent to ${u.toString()}").getOrElse("")
-    val requestIdMessage = requestId.map(id => s", with request id ${id}").getOrElse("")
-    val superString: String = super.toString
+    val responseCodeMessage = responseCode
+      .map(c => s" (with response code ${c.toString})")
+      .getOrElse("")
+    val uriMessage = uri
+      .map(u => s", in response$responseCodeMessage to request sent to ${u.toString()}")
+      .getOrElse("")
+    val requestIdMessage = requestId.map(id => s", with request id $id").getOrElse("")
+    val superString = super.toString
     val superMessage = if (superString.length > 0) {
       superString
     } else {
       "Missing error message"
     }
-    s"$superMessage$uriMessage$requestIdMessage"
+    s"$superMessage$uriMessage$responseCodeMessage$requestIdMessage"
   }
 }
 final case class CdpApiErrorPayload(

--- a/src/main/scala/com/cognite/sdk/scala/common/login.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/login.scala
@@ -1,35 +1,23 @@
 package com.cognite.sdk.scala.common
 
-import java.net.{ConnectException, UnknownHostException}
-
 import com.cognite.sdk.scala.v1.RequestSession
 import com.softwaremill.sttp._
-import com.softwaremill.sttp.circe._
+import io.circe.Decoder
 import io.circe.derivation.deriveDecoder
 
 final case class LoginStatus(user: String, loggedIn: Boolean, project: String, projectId: Long)
 final case class DataLoginStatus(data: LoginStatus)
+
 class Login[F[_]](val requestSession: RequestSession[F]) {
   @SuppressWarnings(Array("org.wartremover.warts.EitherProjectionPartial"))
-  implicit val loginStatusDecoder = deriveDecoder[LoginStatus]
-  implicit val dataLoginStatusDecoder = deriveDecoder[DataLoginStatus]
+  implicit val loginStatusDecoder: Decoder[LoginStatus] = deriveDecoder[LoginStatus]
+  implicit val dataLoginStatusDecoder: Decoder[DataLoginStatus] = deriveDecoder[DataLoginStatus]
+  implicit val errorOrDataLoginStatusDecoder: Decoder[Either[CdpApiError, DataLoginStatus]] =
+    EitherDecoder.eitherDecoder[CdpApiError, DataLoginStatus]
   def status(): F[LoginStatus] =
-    try {
-      requestSession
-        .sendCdf { request =>
-          request
-            .get(uri"${requestSession.baseUri}/login/status")
-            .response(asJson[DataLoginStatus])
-            .mapResponse {
-              case Left(value) => throw value.error
-              case Right(value) => value.data
-            }
-        }
-    } catch {
-      case e @ (_: UnknownHostException | _: ConnectException) => throw e
-      case _: io.circe.ParsingFailure =>
-        throw new RuntimeException(
-          s"Could not connect to Cognite Data Fusion API using baseUri ${requestSession.baseUri.toString()}"
-        )
-    }
+    requestSession
+      .get[LoginStatus, DataLoginStatus](
+        uri"${requestSession.baseUri}/login/status",
+        value => value.data
+      )
 }

--- a/src/main/scala/com/cognite/sdk/scala/v1/package.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/package.scala
@@ -2,6 +2,8 @@ package com.cognite.sdk.scala
 
 import java.util.concurrent.Executors
 
+import scala.concurrent.duration._
+
 import cats.{Comonad, Id}
 import cats.effect.IO
 import com.softwaremill.sttp.{HttpURLConnectionBackend, SttpBackend}
@@ -13,7 +15,11 @@ package object v1 {
   implicit val executionContext: ExecutionContext =
     ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
   implicit val sttpBackend: SttpBackend[Id, Nothing] =
-    new RetryingBackend[Id, Nothing](HttpURLConnectionBackend())
+    new RetryingBackend[Id, Nothing](
+      HttpURLConnectionBackend(),
+      initialRetryDelay = 100.millis,
+      maxRetryDelay = 200.millis
+    )
 
   // This is ugly and not great, but we need to do something hacky one
   // way or another to be able to support both IO and Id types.

--- a/src/test/scala/com/cognite/sdk/scala/common/LoginTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/LoginTest.scala
@@ -5,7 +5,7 @@ import com.softwaremill.sttp._
 
 import scala.concurrent.duration._
 
-class LoginTest extends SdkTest {
+class LoginTest extends SdkTestSpec {
   implicit val backend: SttpBackend[Id, Nothing] = HttpURLConnectionBackend(
     options = SttpBackendOptions.connectionTimeout(90.seconds)
   )

--- a/src/test/scala/com/cognite/sdk/scala/v1/ApiKeysTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ApiKeysTest.scala
@@ -1,7 +1,7 @@
 package com.cognite.sdk.scala.v1
 
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec}
 
-class ApiKeysTest extends SdkTest with ReadBehaviours {
+class ApiKeysTest extends SdkTestSpec with ReadBehaviours {
   "ApiKeys" should behave like readable(client.apiKeys, supportsLimit = false)
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
@@ -2,10 +2,10 @@ package com.cognite.sdk.scala.v1
 
 import java.time.Instant
 import com.cognite.sdk.scala.common.RetryWhile
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest, SetValue, WritableBehaviors}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec, SetValue, WritableBehaviors}
 import fs2.Stream
 
-class AssetsTest extends SdkTest with ReadBehaviours with WritableBehaviors with RetryWhile {
+class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with RetryWhile {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -1,58 +1,66 @@
 package com.cognite.sdk.scala.v1
 
 import java.net.UnknownHostException
+import java.nio.charset.Charset
+import java.time.Instant
+import java.util.Base64
 
-import cats.{Comonad, Id, Monad}
+import cats.Id
 import cats.effect._
-import com.cognite.sdk.scala.common.{ApiKeyAuth, Auth, CdpApiException, InvalidAuthentication, RetryingBackend, SdkException, SdkTest}
-import com.softwaremill.sttp.Response
+import com.cognite.sdk.scala.common.{ApiKeyAuth, Auth, CdpApiException, InvalidAuthentication, RetryingBackend, SdkException, SdkTestSpec}
+import com.softwaremill.sttp.{Response, SttpBackend}
 import com.softwaremill.sttp.asynchttpclient.cats.AsyncHttpClientCatsBackend
 import com.softwaremill.sttp.testing.SttpBackendStub
 
+import scala.collection.immutable.Seq
 import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
 
-class ClientTest extends SdkTest {
+class ClientTest extends SdkTestSpec {
   "Client" should "fetch the project using login/status if necessary" in {
-    noException should be thrownBy new GenericClient(
+    noException should be thrownBy new GenericClient[Id, Nothing](
       "scala-sdk-test")(
-      implicitly[Monad[Id]],
-      implicitly[Comonad[Id]],
+      implicitly,
+      implicitly,
       auth,
       sttpBackend
     )
-    new GenericClient("scala-sdk-test")(
-      implicitly[Monad[Id]],
-      implicitly[Comonad[Id]],
+    new GenericClient[Id, Nothing]("scala-sdk-test")(
+      implicitly,
+      implicitly,
       auth,
       sttpBackend
     ).projectName should not be empty
   }
+
   it should "support async IO clients" in {
     implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
     implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
     new GenericClient[IO, Nothing]("scala-sdk-test")(
-      implicitly[Monad[IO]],
-      implicitly[Comonad[IO]],
+      implicitly,
+      implicitly,
       auth,
       new RetryingBackend[IO, Nothing](AsyncHttpClientCatsBackend[IO]())
     ).projectName should not be empty
   }
+
   it should "throw an exception if the authentication is invalid and project is not specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key")
-    an[InvalidAuthentication] should be thrownBy new GenericClient(
+    an[InvalidAuthentication] should be thrownBy new GenericClient[Id, Nothing](
       "scala-sdk-test")(
-      implicitly[Monad[Id]],
-      implicitly[Comonad[Id]],
+      implicitly,
+      implicitly,
       auth,
       sttpBackend
     ).assets.list(Some(1)).compile.toList
   }
+
   it should "not throw an exception if the authentication is invalid and project is specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key", project = Some("random-project"))
-    noException should be thrownBy new GenericClient(
+    noException should be thrownBy new GenericClient[Id, Nothing](
       "scala-sdk-test")(
-      implicitly[Monad[Id]],
-      implicitly[Comonad[Id]],
+      implicitly,
+      implicitly,
       auth,
       sttpBackend
     )
@@ -61,11 +69,11 @@ class ClientTest extends SdkTest {
   it should "be possible to use the sdk with greenfield.cognite.data.com" in {
     implicit val auth: Auth = ApiKeyAuth(Option(System.getenv("TEST_API_KEY_GREENFIELD"))
       .getOrElse(throw new RuntimeException("TEST_API_KEY_GREENFIELD not set")))
-    noException should be thrownBy new GenericClient(
+    noException should be thrownBy new GenericClient[Id, Nothing](
       "cdp-spark-datasource-test",
       "https://greenfield.cognitedata.com"
-    )(implicitly[Monad[Id]],
-      implicitly[Comonad[Id]],
+    )(implicitly,
+      implicitly,
       auth,
       sttpBackend
     )
@@ -93,55 +101,195 @@ class ClientTest extends SdkTest {
   }
 
   private val loginStatus = client.login.status()
-  private def makeTestingBackend() = {
+  private val loginStatusResponse = new Response(Right(
+    s"""
+       |{
+       |  "data": {
+       |    "user": "tom@example.com",
+       |    "loggedIn": true,
+       |    "project": "${loginStatus.project}",
+       |    "projectId": ${loginStatus.projectId}
+       |  }
+       |}
+       |""".stripMargin), 200, "",
+    Seq(("x-request-id", "test-request-header"), ("content-type", "application/json; charset=utf-8")),
+    Nil)
+  private def makeTestingBackend(): SttpBackend[Id, Nothing] = {
     val errorResponse = new Response(Right("{\n  \"error\": {\n    \"code\": 429,\n    \"message\": \"Some error\"\n  }\n}"),
-      429, "", scala.collection.immutable.Seq[(String, String)](("x-request-id", "test-request-header")), Nil)
+      429, "", Seq(("x-request-id", "test-request-header")), Nil)
     val successResponse = new Response(Right(
       "{\n  \"items\": [\n{\n  \"id\": 5238663994907390,\n  \"createdTime\":" +
         " 1550760030463,\n  \"name\": \"model_793601675501121482\"\n}\n  ]\n}"),
-      200, "", scala.collection.immutable.Seq[(String, String)](("x-request-id", "test-request-header")), Nil)
-    val loginStatusResponse = new Response(Right(
-      s"""
-         |{
-         |  "data": {
-         |    "user": "tom@example.com",
-         |    "loggedIn": true,
-         |    "project": "${loginStatus.project}",
-         |    "projectId": ${loginStatus.projectId}
-         |  }
-         |}
-         |""".stripMargin), 200, "",
-      scala.collection.immutable.Seq[(String, String)](("x-request-id", "test-request-header")),
-      Nil)
+      200, "", Seq(("x-request-id", "test-request-header")), Nil)
     SttpBackendStub.synchronous
       .whenAnyRequest
       .thenRespondCyclicResponses(loginStatusResponse, errorResponse, errorResponse, errorResponse, errorResponse, errorResponse, successResponse
       )
   }
+
   it should "retry certain failed requests" in {
     assertThrows[CdpApiException] {
-      new GenericClient("scala-sdk-test")(
-        implicitly[Monad[Id]],
-        implicitly[Comonad[Id]],
+      new GenericClient[Id, Nothing]("scala-sdk-test")(
+        implicitly,
+        implicitly,
         auth,
         makeTestingBackend()
       ).threeDModels.list()
     }
 
-    val _ = new GenericClient("scala-sdk-test")(
-      implicitly[Monad[Id]],
-      implicitly[Comonad[Id]],
+    val _ = new GenericClient[Id, Nothing]("scala-sdk-test")(
+      implicitly,
+      implicitly,
       auth,
-      new RetryingBackend[Id, Nothing](makeTestingBackend())
+      new RetryingBackend[Id, Nothing](
+        makeTestingBackend(),
+        initialRetryDelay = 1.millis,
+        maxRetryDelay = 2.millis)
     ).threeDModels.list()
 
     assertThrows[CdpApiException] {
-      new GenericClient("scala-sdk-test")(
-        implicitly[Monad[Id]],
-        implicitly[Comonad[Id]],
+      new GenericClient[Id, Nothing]("scala-sdk-test")(
+        implicitly,
+        implicitly,
         auth,
-        new RetryingBackend[Id, Nothing](makeTestingBackend(), Some(4))
+        new RetryingBackend[Id, Nothing](
+          makeTestingBackend(),
+          Some(4),
+          initialRetryDelay = 1.millis,
+          maxRetryDelay = 2.millis)
       ).threeDModels.list()
     }
+  }
+
+  it should "retry requests based on response code if the response is empty" in {
+    val badGatewayResponseLeft = new Response(Right(""),
+      502, "", Seq.empty, Nil)
+    val badGatewayResponseRight = new Response(Right(""),
+      502, "", Seq.empty, Nil)
+    val unavailableResponse = new Response(Right(""),
+      503, "", Seq(("content-type", "application/json; charset=utf-8")), Nil)
+    val serverError = new Response(Right(""),
+      503, "", Seq(("content-type", "application/protobuf")), Nil)
+    val backendStub = SttpBackendStub.synchronous
+      .whenAnyRequest
+      .thenRespondCyclicResponses(
+        badGatewayResponseLeft,
+        badGatewayResponseRight,
+        unavailableResponse,
+        serverError,
+        loginStatusResponse)
+    val client = new GenericClient[Id, Nothing]("scala-sdk-test",
+      "https://www.cognite.com/nowhereatall"
+    )(
+      implicitly,
+      implicitly,
+      ApiKeyAuth("irrelevant", Some("randomproject")),
+      new RetryingBackend[Id, Nothing](backendStub,
+        initialRetryDelay = 1.millis,
+        maxRetryDelay = 2.millis)
+    )
+    client.login.status().project shouldBe (loginStatus.project)
+  }
+
+  it should "retry JSON requests based on response code if content type is unknown" in {
+    val badGatewayResponse: Response[String] = new Response(Left("Bad Gateway".getBytes(Charset.forName("utf-8"))),
+      502, "", Seq(("content-type", "text/html")), Nil)
+    val unavailableResponse: Response[String]  = new Response(Right("Service Unavailable"),
+      503, "", Seq.empty, Nil)
+    val serverError: Response[String]  = new Response(Right("Error"),
+      503, "", Seq(("content-type", "text/plain")), Nil)
+    val serverErrorHtml: Response[String]  = new Response(Right("Error"),
+      503, "", Seq(("content-type", "text/html; charset=UTF-8")), Nil)
+    val badRequest: Response[String]  = new Response(Right(""),
+      503, "", Seq(("content-type", "unknown")), Nil)
+    val assetsResponse = new Response(Right(
+      s"""
+         |{
+         |  "items": [{
+         |    "name": "some-asset",
+         |    "externalId": "ext-123",
+         |    "parentId": 123,
+         |    "description": "asdf",
+         |    "metadata": {},
+         |    "source": "test",
+         |    "id": 144,
+         |    "createdTime": 1546300800000,
+         |    "lastUpdatedTime": 1546300800000,
+         |    "rootId": 199
+         |  }]
+         |}
+         |""".stripMargin), 200, "",
+      Seq(("x-request-id", "test-request-header"), ("content-type", "application/json; charset=utf-8")),
+      Nil)
+    val badRequestBackendStub = SttpBackendStub.synchronous
+      .whenAnyRequest
+      .thenRespondCyclicResponses(
+        badGatewayResponse,
+        unavailableResponse,
+        serverError,
+        serverErrorHtml,
+        badRequest,
+        loginStatusResponse,
+        badGatewayResponse,
+        unavailableResponse,
+        serverError,
+        serverErrorHtml,
+        badRequest,
+        assetsResponse
+      )
+    val client = new GenericClient[Id, Nothing]("scala-sdk-test",
+      "https://www.cognite1999.com/nowhere-at-all"
+    )(
+      implicitly,
+      implicitly,
+      ApiKeyAuth("irrelevant", Some("randomproject")),
+      new RetryingBackend[Id, Nothing](
+        badRequestBackendStub,
+        initialRetryDelay = 1.millis,
+        maxRetryDelay = 2.millis)
+    )
+    client.login.status().project shouldBe loginStatus.project
+    client.assets.list().compile.toList.length should be > 0
+  }
+
+  it should "retry protobuf requests based on response code if content type is unknown" in {
+    val protobufBase64 = "CjYIrt3fh6WwSRIYVkFMXzIzLVBESS05NjE0OTpYLlZhbHVlGhIKEAi9/ta1gC0RAAAAQA0v/T8="
+    val protobufResponse: Response[Array[Byte]] = new Response(Right(Base64.getDecoder.decode(protobufBase64)),
+      400, "", Seq(("content-type", "application/protobuf")), Nil)
+
+    val badGatewayResponseBytes: Response[Array[Byte]] = new Response(Left("Bad Gateway".getBytes("utf-8")),
+      502, "", Seq(("content-type", "text/html")), Nil)
+    val unavailableResponseBytes: Response[Array[Byte]]  = new Response(Right("Service Unavailable".getBytes("utf-8")),
+      503, "", Seq.empty, Nil)
+    val serverErrorBytes: Response[Array[Byte]]  = new Response(Right("Error".getBytes("utf-8")),
+      503, "", Seq(("content-type", "text/plain")), Nil)
+    val serverErrorHtmlBytes: Response[Array[Byte]]  = new Response(Right("Error".getBytes("utf-8")),
+      503, "", Seq(("content-type", "text/html; charset=UTF-8")), Nil)
+    val badRequestBytes: Response[Array[Byte]]  = new Response(Right("".getBytes("utf-8")),
+      503, "", Seq(("content-type", "unknown")), Nil)
+    val badRequestBackendStub1 = SttpBackendStub.synchronous
+      .whenAnyRequest
+      .thenRespondCyclicResponses(badGatewayResponseBytes,
+        unavailableResponseBytes,
+        serverErrorBytes,
+        serverErrorHtmlBytes,
+        badRequestBytes,
+        protobufResponse)
+    val client2 = new GenericClient[Id, Nothing]("scala-sdk-test",
+      "https://www.cognite1999.com/nowhere-at-all"
+    )(
+      implicitly,
+      implicitly,
+      ApiKeyAuth("irrelevant", Some("randomproject")),
+      new RetryingBackend[Id, Nothing](
+        badRequestBackendStub1,
+        initialRetryDelay = 1.millis,
+        maxRetryDelay = 2.millis)
+    )
+    val points = client2.dataPoints.queryById(123, Instant.ofEpochMilli(1546300800000L), Instant.ofEpochMilli(1546900000000L), None)
+    // True value is 1.8239872455596924, but to avoid issues with Scala 2.13 deprecation of
+    // double ordering we compare at integer level.
+    scala.math.floor(points.datapoints.head.value * 10).toInt shouldBe 18
+    scala.math.ceil(points.datapoints.head.value * 10).toInt shouldBe 19
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
@@ -3,9 +3,9 @@ package com.cognite.sdk.scala.v1
 import java.time.Instant
 import java.util.UUID
 
-import com.cognite.sdk.scala.common.{CdpApiException, DataPointsResourceBehaviors, SdkTest}
+import com.cognite.sdk.scala.common.{CdpApiException, DataPointsResourceBehaviors, SdkTestSpec}
 
-class DataPointsTest extends SdkTest with DataPointsResourceBehaviors {
+class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
   override def withTimeSeries(testCode: TimeSeries => Any): Unit = {
     val name = Some(s"data-points-test-${UUID.randomUUID().toString}")
     val timeSeries = client.timeSeries

--- a/src/test/scala/com/cognite/sdk/scala/v1/EventsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/EventsTest.scala
@@ -3,9 +3,9 @@ package com.cognite.sdk.scala.v1
 import java.time.Instant
 
 import fs2._
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest, SetValue, WritableBehaviors}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec, SetValue, WritableBehaviors}
 
-class EventsTest extends SdkTest with ReadBehaviours with WritableBehaviors {
+class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/FilesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/FilesTest.scala
@@ -6,9 +6,9 @@ import java.time.Instant
 import java.util.UUID
 
 import org.scalatest.Matchers
-import com.cognite.sdk.scala.common.{CdpApiException, ReadBehaviours, SdkTest, SetValue, WritableBehaviors}
+import com.cognite.sdk.scala.common.{CdpApiException, ReadBehaviours, SdkTestSpec, SetValue, WritableBehaviors}
 
-class FilesTest extends SdkTest with ReadBehaviours with WritableBehaviors with Matchers {
+class FilesTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with Matchers {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
@@ -1,9 +1,9 @@
 package com.cognite.sdk.scala.v1
 
 import java.util.UUID
-import com.cognite.sdk.scala.common.{DataPointsResourceBehaviors, SdkTest}
+import com.cognite.sdk.scala.common.{DataPointsResourceBehaviors, SdkTestSpec}
 
-class GreenfieldDataPointsTest extends SdkTest with DataPointsResourceBehaviors {
+class GreenfieldDataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
   override def withTimeSeries(testCode: TimeSeries => Any): Unit = {
     val name = Some(s"data-points-test-${UUID.randomUUID().toString}")
     val timeSeries = greenfieldClient.timeSeries.createFromRead(

--- a/src/test/scala/com/cognite/sdk/scala/v1/GroupsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/GroupsTest.scala
@@ -1,7 +1,7 @@
 package com.cognite.sdk.scala.v1
 
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec}
 
-class GroupsTest extends SdkTest with ReadBehaviours {
+class GroupsTest extends SdkTestSpec with ReadBehaviours {
   "Groups" should behave like readable(client.groups, supportsLimit = false)
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/ProjectTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ProjectTest.scala
@@ -1,8 +1,8 @@
 package com.cognite.sdk.scala.v1
 
-import com.cognite.sdk.scala.common.SdkTest
+import com.cognite.sdk.scala.common.SdkTestSpec
 
-class ProjectTest extends SdkTest {
+class ProjectTest extends SdkTestSpec {
   // TODO: We don't have sufficient permissions in publicdata or Greenfield
   "Project" should "be retrievable and correct" ignore {
     greenfieldClient.project.name shouldNot be (empty)

--- a/src/test/scala/com/cognite/sdk/scala/v1/RawTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/RawTest.scala
@@ -1,11 +1,11 @@
 package com.cognite.sdk.scala.v1
 
 import cats.syntax.either._
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest, WritableBehaviors}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec, WritableBehaviors}
 import fs2.Stream
 import io.circe.syntax._
 
-class RawTest extends SdkTest with ReadBehaviours with WritableBehaviors {
+class RawTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
   private val idsThatDoNotExist = Seq("nodatabase", "randomdatabase")
 
   it should behave like readable(client.rawDatabases)

--- a/src/test/scala/com/cognite/sdk/scala/v1/SecurityCategoriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SecurityCategoriesTest.scala
@@ -1,11 +1,11 @@
 package com.cognite.sdk.scala.v1
 
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec}
 // FIXME: Not sure why @Ignore isn't working. "behave like" doesn't seem to support ignore.
 //import org.scalatest.Ignore
 //
 //@Ignore
-class SecurityCategoriesTest extends SdkTest with ReadBehaviours {
+class SecurityCategoriesTest extends SdkTestSpec with ReadBehaviours {
   // TODO: We don't have any security categories in publicdata,
   //  and lack permissions to list them in greenfield
 //  "SecurityCategories" should behave like readable(client.securityCategories, supportsLimit = false)

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
@@ -1,11 +1,11 @@
 package com.cognite.sdk.scala.v1
 
 import cats.data.NonEmptyList
-import com.cognite.sdk.scala.common.{RetryWhile, SdkTest}
+import com.cognite.sdk.scala.common.{RetryWhile, SdkTestSpec}
 import io.circe.syntax._
 import org.scalatest.ParallelTestExecution
 
-class SequenceRowsTest extends SdkTest with ParallelTestExecution with RetryWhile {
+class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with RetryWhile {
   def withSequence(testCode: Sequence => Any): Unit = {
     val externalId = shortRandom()
     val sequence = client.sequences.createOneFromRead(

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequencesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequencesTest.scala
@@ -3,9 +3,9 @@ package com.cognite.sdk.scala.v1
 import java.time.Instant
 
 import cats.data.NonEmptyList
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest, SetValue, WritableBehaviors}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec, SetValue, WritableBehaviors}
 
-class SequencesTest extends SdkTest with ReadBehaviours with WritableBehaviors {
+class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("sequence-5PNii0w", "sequence-6VhKQqt")
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/ServiceAccountsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ServiceAccountsTest.scala
@@ -1,11 +1,11 @@
 package com.cognite.sdk.scala.v1
 
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec}
 // FIXME: Not sure why @Ignore isn't working. "behave like" doesn't seem to support ignore.
 //import org.scalatest.Ignore
 //
 //@Ignore
-class ServiceAccountsTest extends SdkTest with ReadBehaviours {
+class ServiceAccountsTest extends SdkTestSpec with ReadBehaviours {
   // TODO: We don't have permissions to list service accounts
 //  "ServiceAccounts" should behave like readable(client.serviceAccounts)
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/StringDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/StringDataPointsTest.scala
@@ -1,9 +1,9 @@
 package com.cognite.sdk.scala.v1
 
 import java.util.UUID
-import com.cognite.sdk.scala.common.{SdkTest, StringDataPointsResourceBehaviors}
+import com.cognite.sdk.scala.common.{SdkTestSpec, StringDataPointsResourceBehaviors}
 
-class StringDataPointsTest extends SdkTest with StringDataPointsResourceBehaviors {
+class StringDataPointsTest extends SdkTestSpec with StringDataPointsResourceBehaviors {
   override def withStringTimeSeries(testCode: TimeSeries => Any): Unit = {
     val name = Some(s"string-data-points-test-${UUID.randomUUID().toString}")
     val timeSeries = client.timeSeries.createFromRead(

--- a/src/test/scala/com/cognite/sdk/scala/v1/ThreeDTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ThreeDTest.scala
@@ -2,9 +2,9 @@ package com.cognite.sdk.scala.v1
 
 import java.time.Instant
 
-import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTest, WritableBehaviors}
+import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec, WritableBehaviors}
 
-class ThreeDTest extends SdkTest with ReadBehaviours with WritableBehaviors {
+class ThreeDTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
   private val idsThatDoNotExist = Seq(9999991L, 9999992L)
 
   ("ThreeDModels" should behave).like(readable(client.threeDModels))

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -1,10 +1,10 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-import com.cognite.sdk.scala.common.{DataPoint, ReadBehaviours, RetryWhile, SdkTest, SetValue, WritableBehaviors}
+import com.cognite.sdk.scala.common.{DataPoint, ReadBehaviours, RetryWhile, SdkTestSpec, SetValue, WritableBehaviors}
 import fs2.Stream
 
-class TimeSeriesTest extends SdkTest with ReadBehaviours with WritableBehaviors with RetryWhile {
+class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with RetryWhile {
   private val idsThatDoNotExist = Seq(999991L, 999992L, 999993L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
 


### PR DESCRIPTION
Which also means we do retries on them, according to the status code.