### PR TITLE
SdkException creates a user-friendly message

### DIFF
--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -254,7 +254,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
           search = Some(TimeSeriesSearch(name = Some("W0405")))
         )
       )
-    assert(nameSearchResults.length == 12)
+    assert(nameSearchResults.length == 19)
 
     val descriptionSearchResults = client.timeSeries.search(
       TimeSeriesQuery(


### PR DESCRIPTION
 SdkException creates a user-friendly message instead of overriding toString method. It seems that the toString method is actually not really called (for example, ScalaTest did not the print the full message), but I'm not sure what is the correct convention for Scala/Java.