### PR TITLE
align threeD node bounding box with API spec

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
@@ -28,8 +28,8 @@ final case class Camera(
 )
 
 final case class BoundingBox(
-    max: Option[Array[Double]],
-    min: Option[Array[Double]]
+    max: Array[Double],
+    min: Array[Double]
 )
 
 final case class Properties(


### PR DESCRIPTION
bounding box elements are mandatory: https://docs.cognite.com/api/v1/#operation/get3DNodes