### PR TITLE
Remove redundant Option from BoundingBox max/min

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
@@ -28,8 +28,8 @@ final case class Camera(
 )
 
 final case class BoundingBox(
-    max: Option[Seq[Double]],
-    min: Option[Seq[Double]]
+    max: Seq[Double],
+    min: Seq[Double]
 )
 
 final case class Properties(


### PR DESCRIPTION
They're always present, a bounding box with only one or the other,
or none, does not make sense.