### PR TITLE
Simplify retryWithExpectedResult used in tests

### DIFF
--- a/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
@@ -27,53 +27,51 @@ trait DataPointsResourceBehaviors extends Matchers with RetryWhile { this: FlatS
 
         retryWithExpectedResult[DataPointsByIdResponse](
           dataPoints.queryById(timeSeriesId, start, end.plusMillis(1)),
-          None,
-          Seq(p => p.datapoints should have size testDataPoints.size.toLong)
+          p => p.datapoints should have size testDataPoints.size.toLong
         )
 
         retryWithExpectedResult[DataPointsByIdResponse](
           dataPoints.queryById(timeSeriesId, start, end.plusMillis(1), Some(3)),
-          None,
-          Seq(p => p.datapoints should have size 3)
+          p => p.datapoints should have size 3
         )
 
         retryWithExpectedResult[Option[DataPoint]](
           dataPoints.getLatestDataPointById(timeSeriesId),
-          None,
-          Seq(dp => dp.isDefined shouldBe true, dp => testDataPoints.toList should contain(dp.get))
+          dp => {
+            dp.isDefined shouldBe true
+            testDataPoints.toList should contain(dp.get)
+          }
         )
 
         dataPoints.deleteRangeById(timeSeriesId, start, end.plusMillis(1))
         retryWithExpectedResult[DataPointsByIdResponse](
           dataPoints.queryById(timeSeriesId, start, end.plusMillis(1)),
-          None,
-          Seq(dp => dp.datapoints should have size 0)
+          dp => dp.datapoints should have size 0
         )
 
         dataPoints.insertByExternalId(timeSeriesExternalId, testDataPoints)
         retryWithExpectedResult[DataPointsByIdResponse](
           dataPoints.queryByExternalId(timeSeriesExternalId, start, end.plusMillis(1)),
-          None,
-          Seq(p2 => p2.datapoints should have size testDataPoints.size.toLong)
+          p2 => p2.datapoints should have size testDataPoints.size.toLong
         )
 
         retryWithExpectedResult[DataPointsByIdResponse](
           dataPoints.queryByExternalId(timeSeriesExternalId, start, end.plusMillis(1), Some(5)),
-          None,
-          Seq(p2 => p2.datapoints should have size 5)
+          p2 => p2.datapoints should have size 5
         )
 
         retryWithExpectedResult[Option[DataPoint]](
           dataPoints.getLatestDataPointByExternalId(timeSeriesExternalId),
-          None,
-          Seq(l2 => l2.isDefined shouldBe true, l2 => testDataPoints.toList should contain(l2.get))
+          { l2 =>
+            l2.isDefined shouldBe true
+            testDataPoints.toList should contain(l2.get)
+          }
         )
 
         dataPoints.deleteRangeByExternalId(timeSeriesExternalId, start, end.plusMillis(1))
         retryWithExpectedResult[DataPointsByIdResponse](
           dataPoints.queryByExternalId(timeSeriesExternalId, start, end.plusMillis(1)),
-          None,
-          Seq(pad => pad.datapoints should have size 0)
+          pad => pad.datapoints should have size 0
         )
     }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
@@ -8,29 +8,24 @@ import org.scalatest.exceptions.TestFailedException
 
 trait RetryWhile {
   def retryWithExpectedResult[A](
-        action: => A,
-        result: Option[A],
-        shouldRetry: Seq[A => Assertion],
-        retriesRemaining: Int = Constants.DefaultMaxRetries,
-        initialDelay: FiniteDuration = Constants.DefaultInitialRetryDelay
-      ): A = {
+      action: => A,
+      assertion: A => Assertion,
+      retriesRemaining: Int = Constants.DefaultMaxRetries,
+      initialDelay: FiniteDuration = Constants.DefaultInitialRetryDelay
+  ): A = {
     val exponentialDelay = (Constants.DefaultMaxBackoffDelay / 2).min(initialDelay * 2)
-    val randomDelayScale = (Constants.DefaultMaxBackoffDelay / 2).min(Constants.DefaultInitialRetryDelay * 2).toMillis
+    val randomDelayScale =
+      (Constants.DefaultMaxBackoffDelay / 2).min(Constants.DefaultInitialRetryDelay * 2).toMillis
     val nextDelay = Random.nextInt(randomDelayScale.toInt).millis + exponentialDelay
-    shouldRetry.foreach(assertion => {
-        try {
-          assertion(result.getOrElse(action))
-        } catch {
-          case testFailed: TestFailedException =>
-          if (retriesRemaining > 0) {
-            Thread.sleep(initialDelay.toMillis)
-            val actionValue = action
-            retryWithExpectedResult[A](action, Some(actionValue), Seq(assertion), retriesRemaining - 1, nextDelay)
-          } else {
-            throw testFailed
-          }
-        }
-      })
-    result.getOrElse(action)
+    try {
+      val result = action
+      assertion(result)
+      result
+    } catch {
+      case _: TestFailedException if (retriesRemaining > 0) => {
+        Thread.sleep(initialDelay.toMillis)
+        retryWithExpectedResult[A](action, assertion, retriesRemaining - 1, nextDelay)
+      }
+    }
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/StringDataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/StringDataPointsResourceBehaviors.scala
@@ -27,42 +27,41 @@ trait StringDataPointsResourceBehaviors extends Matchers with RetryWhile { this:
 
         retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
           dataPoints.queryStringsById(stringTimeSeriesId, start, end.plusMillis(1)),
-          None,
-          Seq(p => p.head.datapoints should have size testStringDataPoints.size.toLong)
+          p => p.head.datapoints should have size testStringDataPoints.size.toLong
         )
 
         retryWithExpectedResult[Option[StringDataPoint]](
           dataPoints.getLatestStringDataPointById(stringTimeSeriesId),
-          None,
-          Seq(dp => dp.isDefined shouldBe true, dp => testStringDataPoints.toList should contain(dp.get))
+          dp => {
+            dp.isDefined shouldBe true
+            testStringDataPoints.toList should contain(dp.get)
+          }
         )
 
         dataPoints.deleteRangeById(stringTimeSeriesId, start, end.plusMillis(1))
         retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
           dataPoints.queryStringsById(stringTimeSeriesId, start, end.plusMillis(1)),
-          None,
-          Seq(dp => dp.head.datapoints should have size 0)
+          dp => dp.head.datapoints should have size 0
         )
 
         dataPoints.insertStringsByExternalId(stringTimeSeriesExternalId, testStringDataPoints)
         retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
           dataPoints.queryStringsByExternalId(stringTimeSeriesExternalId, start, end.plusMillis(1)),
-          None,
-          Seq(p2 => p2.head.datapoints should have size testStringDataPoints.size.toLong)
+          p2 => p2.head.datapoints should have size testStringDataPoints.size.toLong
         )
 
-        val latest2 = dataPoints.getLatestStringDataPointByExternalId(stringTimeSeriesExternalId)
         retryWithExpectedResult[Option[StringDataPoint]](
           dataPoints.getLatestStringDataPointByExternalId(stringTimeSeriesExternalId),
-          Some(latest2),
-          Seq(l2 => l2.isDefined shouldBe true, l2 => testStringDataPoints.toList should contain(l2.get))
+          l2 => {
+            l2.isDefined shouldBe true
+            testStringDataPoints.toList should contain(l2.get)
+          }
         )
 
         dataPoints.deleteRangeById(stringTimeSeriesId, start, end.plusMillis(1))
         retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
           dataPoints.queryStringsByExternalId(stringTimeSeriesExternalId, start, end.plusMillis(1)),
-          None,
-          Seq(pad => pad.head.datapoints should have size 0)
+          pad => pad.head.datapoints should have size 0
         )
     }
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
@@ -57,16 +57,14 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
 
     retryWithExpectedResult[Seq[Asset]](
       client.assets.filter(AssetsFilter(externalIdPrefix = Some("recursive"))).compile.toList,
-      None,
-      Seq(r => r should have size 3)
+      r => r should have size 3
     )
 
     client.assets.deleteByExternalIds(Seq("recursive-root"), true, true)
 
     retryWithExpectedResult[Seq[Asset]](
       client.assets.filter(AssetsFilter(externalIdPrefix = Some("recursive"))).compile.toList,
-      None,
-      Seq(r => r should have size 0)
+      r => r should have size 0
     )
   }
 
@@ -144,8 +142,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
         )
         .compile
         .toList,
-      None,
-      Seq(r => r should have size 84)
+      r => r should have size 84
     )
 
     val createdTimeFilterResults = client.assets
@@ -189,8 +186,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
       .fold(Stream.empty)(_ ++ _)
       .compile
       .toList,
-      None,
-      Seq(a => a should have size 1106)
+      a => a should have size 1106
     )
 
     val assetSubtreeIdsFilterResult = client.assets
@@ -210,11 +206,10 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
           rootIds = Some(Seq(CogniteInternalId(7127045760755934L)))
         ), Some(5), Some(Seq("childCount")))
         .compile.toList,
-      None,
-      Seq(a => {
+      a => {
         val bool = a.map(_.aggregates.get("childCount")).exists(_ > 0)
         bool shouldBe true
-      })
+      }
     )
   }
 
@@ -274,7 +269,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
     val created = client.assets.createFromRead(assetsToCreate)
     try {
       val createdTimes = created.map(_.createdTime)
-      val foundItems = retryWithExpectedResult(
+      val foundItems = retryWithExpectedResult[Seq[Asset]](
         client.assets.search(AssetsQuery(Some(AssetsFilter(
           dataSetIds = Some(Seq(CogniteInternalId(testDataSet.id))),
           createdTime = Some(TimeRange(
@@ -282,8 +277,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
             max = createdTimes.max
           ))
         )))),
-        None,
-        Seq((a: Seq[_]) => a should not be empty)
+        a => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
       created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)

--- a/src/test/scala/com/cognite/sdk/scala/v1/EventsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/EventsTest.scala
@@ -266,7 +266,7 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
     val created = client.events.createFromRead(eventsToCreate)
     try {
       val createdTimes = created.map(_.createdTime)
-      val foundItems = retryWithExpectedResult(
+      val foundItems = retryWithExpectedResult[Seq[Event]](
         client.events.search(EventsQuery(Some(EventsFilter(
           dataSetIds = Some(Seq(CogniteInternalId(testDataSet.id))),
           createdTime = Some(TimeRange(
@@ -274,8 +274,7 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
             max = createdTimes.max
           ))
         )))),
-        None,
-        Seq((a: Seq[_]) => a should not be empty)
+        a => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
       created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)

--- a/src/test/scala/com/cognite/sdk/scala/v1/FilesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/FilesTest.scala
@@ -262,7 +262,7 @@ class FilesTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors w
     val created = filesToCreate.map(f => client.files.createOneFromRead(f))
     try {
       val createdTimes = created.map(_.createdTime)
-      val foundItems = retryWithExpectedResult(
+      val foundItems = retryWithExpectedResult[Seq[File]](
         client.files.search(FilesQuery(Some(FilesFilter(
           dataSetIds = Some(Seq(CogniteInternalId(testDataSet.id))),
           createdTime = Some(TimeRange(
@@ -270,8 +270,7 @@ class FilesTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors w
             max = createdTimes.max
           ))
         )))),
-        None,
-        Seq((a: Seq[_]) => a should not be empty)
+        a => a should not be empty
       )
 
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
@@ -39,35 +39,28 @@ class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with Retry
     client.sequenceRows.insertById(sequence.id, sequence.columns.map(_.externalId).toList, testRows)
     val rows = retryWithExpectedResult[Seq[SequenceRow]](
       client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
-      None,
-      Seq(r => r should contain theSameElementsAs testRows)
+      r => r should contain theSameElementsAs testRows
     )
 
     val updateRows = testRows.map { row =>
       row.copy(values = row.values.updated(0, row.values.head.mapString(s => s"${s}-updated")))
     }
     client.sequenceRows.insertById(sequence.id, sequence.columns.map(_.externalId).toList, updateRows)
-    val (_, rowsAfterUpdate) = client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)
     retryWithExpectedResult[Seq[SequenceRow]](
       client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
-      Some(rowsAfterUpdate),
-      Seq(r => r should contain theSameElementsAs updateRows)
+      r => r should contain theSameElementsAs updateRows
     )
 
     client.sequenceRows.deleteById(sequence.id, rows.map(_.rowNumber).take(1))
-    val (_, rowsAfterOneDelete) = client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)
     retryWithExpectedResult[Seq[SequenceRow]](
       client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
-      Some(rowsAfterOneDelete),
-      Seq(r => r should have size testRows.size.toLong - 1 )
+      r => r should have size testRows.size.toLong - 1
     )
 
     client.sequenceRows.deleteById(sequence.id, rows.map(_.rowNumber))
-    val (_, rowsAfterDeleteAll) = client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)
     retryWithExpectedResult[Seq[SequenceRow]](
       client.sequenceRows.queryById(sequence.id, minRow, maxRow + 1)._2,
-      Some(rowsAfterDeleteAll),
-      Seq(r => r shouldBe empty)
+      r => r shouldBe empty
     )
   }
 
@@ -76,8 +69,7 @@ class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with Retry
     client.sequenceRows.insertByExternalId(externalId, sequence.columns.map(_.externalId).toList, testRows)
     val rows = retryWithExpectedResult[Seq[SequenceRow]](
       client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)._2,
-      None,
-      Seq(r => r should contain theSameElementsAs testRows)
+      r => r should contain theSameElementsAs testRows
     )
 
     // note: intentionally using queryById here.
@@ -86,11 +78,9 @@ class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with Retry
     rowsById should contain theSameElementsAs testRows
 
     client.sequenceRows.deleteByExternalId(externalId, rows.map(_.rowNumber))
-    val (_, rowsAfterDeleteAll) = client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)
     retryWithExpectedResult[Seq[SequenceRow]](
       client.sequenceRows.queryByExternalId(externalId, minRow, maxRow + 1)._2,
-      Some(rowsAfterDeleteAll),
-      Seq(r => r shouldBe empty)
+      r => r shouldBe empty
     )
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequencesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequencesTest.scala
@@ -298,8 +298,7 @@ class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehavio
             max = createdTimes.max
           ))
         )))),
-        None,
-        Seq((a: Seq[_]) => a should not be empty)
+        (a: Seq[_]) => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
       created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -286,12 +286,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     client.dataPoints.insertById(timeSeriesID, dp)
     val retrievedDp = client.dataPoints.queryById(
       timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000))
-    retryWithExpectedResult[DataPointsByIdResponse](
-      client.dataPoints.queryById(
-        timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000)),
-      Some(retrievedDp),
-      Seq(dp => dp shouldBe retrievedDp)
-    )
+    retrievedDp shouldBe dp
     client.dataPoints.deleteRangeById(timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000))
   }
 
@@ -307,8 +302,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
             max = createdTimes.max
           ))
         )))),
-        None,
-        Seq((a: Seq[_]) => a should not be empty)
+        (a: Seq[_]) => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
       created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -284,9 +284,10 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     val dp = (startTime to endTime by 1000).map(t =>
         DataPoint(Instant.ofEpochMilli(t), math.random))
     client.dataPoints.insertById(timeSeriesID, dp)
-    val retrievedDp = client.dataPoints.queryById(
-      timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000))
-    retrievedDp shouldBe dp
+    retryWithExpectedResult[DataPointsByIdResponse](
+      client.dataPoints.queryById(
+        timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000)),
+      retrievedDp => retrievedDp.datapoints shouldBe dp)
     client.dataPoints.deleteRangeById(timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000))
   }
 


### PR DESCRIPTION
Before this change, the function used to evaluated the action multiple times
and to prevent that, one had to evaluate the action once more and pass in the
"first result". This was both unintuitive and uncomfortable, now it only
evaluates action once per retry automatically.

Also removes the feature that there could be more than one assertion. This worked in
a very strange way anyway (recursed for each assertion separately?), was not used much,
and is trivial to overcome by simply putting more assertion into one lambda function.

This commit should fix flakyness of some tests (lookup by dataSetId in particular)