### PR TITLE
Support for bulk deletes for DataPoints

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataPoints.scala
@@ -48,17 +48,19 @@ final case class StringDataPointsByExternalId(
     datapoints: Seq[StringDataPoint]
 )
 
+sealed trait DeleteDataPointsRange
+
 final case class DeleteRangeById(
     id: Long,
     inclusiveBegin: Long,
     exclusiveEnd: Long
-)
+) extends DeleteDataPointsRange
 
 final case class DeleteRangeByExternalId(
     externalId: String,
     inclusiveBegin: Long,
     exclusiveEnd: Long
-)
+) extends DeleteDataPointsRange
 
 final case class QueryRangeById(
     id: Long,


### PR DESCRIPTION
The bulk delete is supported by the API, so the Scala SDK should also support it.
I need it to enable deletes in Spark Data Source, as people might be using
for quite large datasets.

Note it is covered by the existing tests for `deleteRangeById` and `deleteRangeByExternalId`