### PR TITLE
[DT-1424] Make limit consistent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ target/
 .attach*
 .bloop/
 .metals/
+.env

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,3 +8,4 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.3")
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.25")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.0"
+addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.146")

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/assets.scala
@@ -124,6 +124,7 @@ class Assets[F[_]](val requestSession: RequestSession[F])
       cursor,
       limit,
       partition,
+      Constants.defaultBatchSize,
       aggregatedProperties
     )
 

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/dataSets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/dataSets.scala
@@ -59,7 +59,15 @@ private[sdk] class DataSets[F[_]](val requestSession: RequestSession[F])
       partition: Option[Partition],
       aggregatedProperties: Option[Seq[String]] = None
   ): F[ItemsWithCursor[DataSet]] =
-    Filter.filterWithCursor(requestSession, baseUrl, filter, cursor, limit, None)
+    Filter.filterWithCursor(
+      requestSession,
+      baseUrl,
+      filter,
+      cursor,
+      limit,
+      partition = None,
+      Constants.defaultBatchSize
+    )
 
   override def search(searchQuery: DataSetQuery): F[Seq[DataSet]] =
     Search.search(requestSession, baseUrl, searchQuery)

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/events.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/events.scala
@@ -76,7 +76,15 @@ class Events[F[_]](val requestSession: RequestSession[F])
       partition: Option[Partition],
       aggregatedProperties: Option[Seq[String]] = None
   ): F[ItemsWithCursor[Event]] =
-    Filter.filterWithCursor(requestSession, baseUrl, filter, cursor, limit, partition)
+    Filter.filterWithCursor(
+      requestSession,
+      baseUrl,
+      filter,
+      cursor,
+      limit,
+      partition,
+      Constants.defaultBatchSize
+    )
 
   override def search(searchQuery: EventsQuery): F[Seq[Event]] =
     Search.search(requestSession, baseUrl, searchQuery)

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/files.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/files.scala
@@ -113,7 +113,15 @@ class Files[F[_]: Applicative](val requestSession: RequestSession[F])
       partition: Option[Partition],
       aggregatedProperties: Option[Seq[String]] = None
   ): F[ItemsWithCursor[File]] =
-    Filter.filterWithCursor(requestSession, baseUrl, filter, cursor, limit, None)
+    Filter.filterWithCursor(
+      requestSession,
+      baseUrl,
+      filter,
+      cursor,
+      limit,
+      partition = None,
+      Constants.defaultBatchSize
+    )
 
   override def search(searchQuery: FilesQuery): F[Seq[File]] =
     Search.search(requestSession, baseUrl, searchQuery)

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/iam.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/iam.scala
@@ -16,13 +16,9 @@ class ServiceAccounts[F[_]](val requestSession: RequestSession[F])
       limit: Option[Int],
       partition: Option[Partition]
   ): F[ItemsWithCursor[ServiceAccount]] =
-    Readable.readWithCursor(
+    Readable.readSimple(
       requestSession,
-      baseUrl,
-      None,
-      None,
-      None,
-      Constants.defaultBatchSize
+      baseUrl
     )
 }
 
@@ -42,13 +38,9 @@ class ApiKeys[F[_]](val requestSession: RequestSession[F]) extends Readable[ApiK
       limit: Option[Int],
       partition: Option[Partition]
   ): F[ItemsWithCursor[ApiKey]] =
-    Readable.readWithCursor(
+    Readable.readSimple(
       requestSession,
-      baseUrl,
-      None,
-      None,
-      None,
-      Constants.defaultBatchSize
+      baseUrl
     )
 }
 
@@ -67,13 +59,9 @@ class Groups[F[_]](val requestSession: RequestSession[F]) extends Readable[Group
       limit: Option[Int],
       partition: Option[Partition]
   ): F[ItemsWithCursor[Group]] =
-    Readable.readWithCursor(
+    Readable.readSimple(
       requestSession,
-      baseUrl,
-      None,
-      None,
-      None,
-      Constants.defaultBatchSize
+      baseUrl
     )
 }
 

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/raw.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/raw.scala
@@ -163,7 +163,7 @@ class RawRows[F[_]](val requestSession: RequestSession[F], database: String, tab
       cursor,
       limit,
       None,
-      Constants.defaultBatchSize
+      Constants.rowsBatchSize
     )
 
   override def filterPartitionsF(

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/timeSeries.scala
@@ -80,7 +80,15 @@ class TimeSeriesResource[F[_]](val requestSession: RequestSession[F])
       partition: Option[Partition],
       aggregatedProperties: Option[Seq[String]] = None
   ): F[ItemsWithCursor[TimeSeries]] =
-    Filter.filterWithCursor(requestSession, baseUrl, filter, cursor, limit, partition)
+    Filter.filterWithCursor(
+      requestSession,
+      baseUrl,
+      filter,
+      cursor,
+      limit,
+      partition,
+      Constants.defaultBatchSize
+    )
 
   override def search(searchQuery: TimeSeriesQuery): F[Seq[TimeSeries]] =
     Search.search(requestSession, baseUrl, searchQuery)

--- a/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
@@ -1,0 +1,54 @@
+package com.cognite.sdk.scala.common
+
+import com.cognite.sdk.scala.v1.Client
+import com.softwaremill.sttp._
+import com.softwaremill.sttp.testing.SttpBackendStub
+import io.circe.parser.decode
+import io.circe.derivation.{deriveDecoder, deriveEncoder}
+
+case class DummyFilter()
+
+class FilterTest extends SdkTestSpec {
+  implicit val dummyFilterEncoder = deriveEncoder[DummyFilter]
+  implicit val dummyFilterRequestEncoder = deriveEncoder[FilterRequest[DummyFilter]]
+  implicit val dummyFilterDecoder = deriveDecoder[DummyFilter]
+  implicit val dummyFilterRequestDecoder = deriveDecoder[FilterRequest[DummyFilter]]
+  implicit val dummyItemsWithCursorDecoder = deriveDecoder[ItemsWithCursor[Int]]
+
+  it should "set final limit to batchSize when less than limit" in filterWithCursor(10, Some(100)) { finalLimit =>
+    finalLimit should be(10)
+  }
+
+  it should "set final limit to limit when less than batchsize" in filterWithCursor(100, Some(20)) { finalLimit =>
+    finalLimit should be(20)
+  }
+
+  it should "set final limit to batchsize when no limit" in filterWithCursor(100, None) { finalLimit =>
+    finalLimit should be(100)
+  }
+
+  def filterWithCursor(batchSize: Int, limit: Option[Int])(test: Int => Any): Any = {
+    var hijackedRequest: FilterRequest[DummyFilter] = null // scalastyle:ignore
+    val requestHijacker = SttpBackendStub.synchronous.whenAnyRequest.thenRespondWrapped(req => {
+      hijackedRequest = decode[FilterRequest[DummyFilter]](req.body.asInstanceOf[StringBody].s).right.get
+      Response(Right(ItemsWithCursor(Seq(0, 1, 2), None)), 200, "OK")
+    })
+    lazy val dummyClient = Client("foo",
+      projectName,
+      auth,
+      "https://api.cognitedata.com")(requestHijacker)
+    val dummyRequestSession = dummyClient.requestSession
+
+    Filter.filterWithCursor(
+      dummyRequestSession,
+      uri"https://test.com",
+      DummyFilter(),
+      None,
+      limit,
+      None,
+      batchSize,
+      None
+    )
+    test(hijackedRequest.limit.get)
+  }
+}

--- a/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
@@ -30,7 +30,10 @@ class FilterTest extends SdkTestSpec {
   def filterWithCursor(batchSize: Int, limit: Option[Int])(test: Int => Any): Any = {
     var hijackedRequest: FilterRequest[DummyFilter] = null // scalastyle:ignore
     val requestHijacker = SttpBackendStub.synchronous.whenAnyRequest.thenRespondWrapped(req => {
-      hijackedRequest = decode[FilterRequest[DummyFilter]](req.body.asInstanceOf[StringBody].s).right.get
+      hijackedRequest = decode[FilterRequest[DummyFilter]](req.body.asInstanceOf[StringBody].s) match {
+        case Right(x) => x
+        case Left(e) => throw e
+      }
       Response(Right(ItemsWithCursor(Seq(0, 1, 2), None)), 200, "OK")
     })
     lazy val dummyClient = Client("foo",

--- a/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
@@ -40,7 +40,7 @@ class ReadTest extends SdkTestSpec {
       None,
       limit,
       None,
-      batchSize,
+      batchSize
     )
     test(totalLimit)
   }

--- a/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
@@ -1,0 +1,47 @@
+package com.cognite.sdk.scala.common
+
+import com.cognite.sdk.scala.v1.Client
+import com.softwaremill.sttp.Uri.QueryFragment
+import com.softwaremill.sttp._
+import com.softwaremill.sttp.testing.SttpBackendStub
+import io.circe.derivation.deriveDecoder
+
+class ReadTest extends SdkTestSpec {
+  implicit val dummyItemsWithCursorDecoder = deriveDecoder[ItemsWithCursor[Int]]
+  it should "set final limit to batchSize when less than limit" in readWithCursor(10, Some(100)) { finalLimit =>
+    finalLimit should be(10)
+  }
+
+  it should "set final limit to limit when less than batchsize" in readWithCursor(100, Some(20)) { finalLimit =>
+    finalLimit should be(20)
+  }
+
+  it should "set final limit to batchsize when no limit" in readWithCursor(100, None) { finalLimit =>
+    finalLimit should be(100)
+  }
+
+  def readWithCursor(batchSize: Int, limit: Option[Int])(test: Int => Any): Any = {
+    var totalLimit = 0
+    val requestHijacker = SttpBackendStub.synchronous.whenAnyRequest.thenRespondWrapped(req => {
+      totalLimit = req.uri.queryFragments.collectFirst {
+        case q @ QueryFragment.KeyValue("limit", _, _, _) => q.v.toInt
+      }.get
+      Response(Right(0), 200, "OK")
+    })
+    lazy val dummyClient = Client("foo",
+      projectName,
+      auth,
+      "https://api.cognitedata.com")(requestHijacker)
+    val dummyRequestSession = dummyClient.requestSession
+
+    Readable.readWithCursor(
+      dummyRequestSession,
+      uri"https://test.com",
+      None,
+      limit,
+      None,
+      batchSize,
+    )
+    test(totalLimit)
+  }
+}


### PR DESCRIPTION
The scala sdk regards the limit to be the total amount of rows returned in some cases, while in other cases it regards it as the batch size.
This PR makes limit consistently reflect the total amount of items.