### PR TITLE
Improved error message for poisoned option in transformers

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
@@ -140,6 +140,10 @@ object Setter {
         case None => None
         case Some(null) => Some(SetNull()) // scalastyle:ignore null
         case Some(value: T) => Some(SetValue(value))
+        case Some(badValue) =>
+          throw new IllegalArgumentException(
+            s"Expected value of type ${manifest[T].toString} but got `${badValue.toString}` of type ${badValue.getClass.toString}"
+          )
       }
     }
 


### PR DESCRIPTION
This error actually occur because of an very strange bug in Spark Data Source
that we could not find - we produce an option with different type inside.

With this change, it at least produces more sensible error message.