### PR TITLE
Remove implicit ExecutionContext

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/package.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/package.scala
@@ -1,18 +1,12 @@
 package com.cognite.sdk.scala
 
-import java.util.concurrent.Executors
-
 import scala.concurrent.duration._
 
 import cats.Id
 import com.softwaremill.sttp.{HttpURLConnectionBackend, SttpBackend}
 import com.cognite.sdk.scala.common.{GzipSttpBackend, RetryingBackend}
 
-import scala.concurrent.ExecutionContext
-
 package object v1 {
-  implicit val executionContext: ExecutionContext =
-    ExecutionContext.fromExecutor(Executors.newCachedThreadPool())
   implicit val sttpBackend: SttpBackend[Id, Nothing] =
     new RetryingBackend[Id, Nothing](
       new GzipSttpBackend[Id, Nothing](


### PR DESCRIPTION
We should not force our users to use the implicit ExecutionContext found in the package object. Instead our users should provide their own. The following resulted in errors before:
```scala
import com.cognite.sdk.scala.v1._
import scala.concurrent.ExecutionContext.Implicits.global
implicitly[ExecutionContext]
```