### PR TITLE
Clean up datapoints and add support for ignoreUnknownIds

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/ReadWritableResource.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/ReadWritableResource.scala
@@ -47,7 +47,7 @@ object DeleteByIds {
       EitherDecoder.eitherDecoder[CdpApiError, Unit]
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
-    requestSession.post[Unit, Unit, ItemsWithIgnoreUnknownIds](
+    requestSession.post[Unit, Unit, ItemsWithIgnoreUnknownIds[CogniteId]](
       ItemsWithIgnoreUnknownIds(ids.map(CogniteInternalId), ignoreUnknownIds),
       uri"$baseUrl/delete",
       _ => ()
@@ -81,7 +81,7 @@ object DeleteByExternalIds {
   ): F[Unit] =
     // TODO: group deletes by max deletion request size
     //       or assert that length of `ids` is less than max deletion request size
-    requestSession.post[Unit, Unit, ItemsWithIgnoreUnknownIds](
+    requestSession.post[Unit, Unit, ItemsWithIgnoreUnknownIds[CogniteId]](
       ItemsWithIgnoreUnknownIds(externalIds.map(CogniteExternalId), ignoreUnknownIds),
       uri"$baseUrl/delete",
       _ => ()

--- a/src/main/scala/com/cognite/sdk/scala/common/ReadableResource.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/ReadableResource.scala
@@ -158,7 +158,7 @@ object RetrieveByIdsWithIgnoreUnknownIds {
   ): F[Seq[R]] = {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
-    requestSession.post[Seq[R], Items[R], ItemsWithIgnoreUnknownIds](
+    requestSession.post[Seq[R], Items[R], ItemsWithIgnoreUnknownIds[CogniteId]](
       ItemsWithIgnoreUnknownIds(ids.map(CogniteInternalId), ignoreUnknownIds),
       uri"$baseUrl/byids",
       value => value.items
@@ -210,7 +210,7 @@ object RetrieveByExternalIdsWithIgnoreUnknownIds {
   ): F[Seq[R]] = {
     implicit val errorOrItemsDecoder: Decoder[Either[CdpApiError, Items[R]]] =
       EitherDecoder.eitherDecoder[CdpApiError, Items[R]]
-    requestSession.post[Seq[R], Items[R], ItemsWithIgnoreUnknownIds](
+    requestSession.post[Seq[R], Items[R], ItemsWithIgnoreUnknownIds[CogniteId]](
       ItemsWithIgnoreUnknownIds(externalIds.map(CogniteExternalId), ignoreUnknownIds),
       uri"$baseUrl/byids",
       value => value.items

--- a/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
@@ -11,7 +11,7 @@ import io.scalaland.chimney.dsl._
 
 final case class ItemsWithCursor[A](items: Seq[A], nextCursor: Option[String] = None)
 final case class Items[A](items: Seq[A])
-final case class ItemsWithIgnoreUnknownIds(items: Seq[CogniteId], ignoreUnknownIds: Boolean)
+final case class ItemsWithIgnoreUnknownIds[A](items: Seq[A], ignoreUnknownIds: Boolean)
 final case class ItemsWithRecursiveAndIgnoreUnknownIds(
     items: Seq[CogniteId],
     recursive: Boolean,

--- a/src/main/scala/com/cognite/sdk/scala/common/package.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/package.scala
@@ -25,7 +25,8 @@ package object common {
   implicit val instantDecoder: Decoder[Instant] = Decoder.decodeLong.map(Instant.ofEpochMilli)
   implicit val timeRangeEncoder: Encoder[TimeRange] = deriveEncoder
 
-  implicit val deleteRequestWithIgnoreUnknownIdsEncoder: Encoder[ItemsWithIgnoreUnknownIds] =
+  implicit val deleteRequestWithIgnoreUnknownIdsEncoder
+      : Encoder[ItemsWithIgnoreUnknownIds[CogniteId]] =
     deriveEncoder
 
 }

--- a/src/main/scala/com/cognite/sdk/scala/v1/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataPoints.scala
@@ -29,7 +29,6 @@ final case class StringDataPointsByIdResponse(
     id: Long,
     externalId: Option[String],
     isString: Boolean,
-    isStep: Option[Boolean],
     unit: Option[String],
     datapoints: Seq[StringDataPoint]
 )
@@ -38,7 +37,6 @@ final case class StringDataPointsByExternalIdResponse(
     id: Long,
     externalId: String,
     isString: Boolean,
-    isStep: Option[Boolean],
     unit: Option[String],
     datapoints: Seq[StringDataPoint]
 )

--- a/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
@@ -2,7 +2,7 @@ package com.cognite.sdk.scala.common
 
 import java.time.Instant
 
-import com.cognite.sdk.scala.v1.{DataPointsByIdResponse, TimeSeries}
+import com.cognite.sdk.scala.v1.{DataPointsByExternalIdResponse, DataPointsByIdResponse, TimeSeries}
 import com.cognite.sdk.scala.v1.resources.DataPointsResource
 import com.softwaremill.sttp.Id
 import org.scalatest.{FlatSpec, Matchers}
@@ -50,12 +50,12 @@ trait DataPointsResourceBehaviors extends Matchers with RetryWhile { this: FlatS
         )
 
         dataPoints.insertByExternalId(timeSeriesExternalId, testDataPoints)
-        retryWithExpectedResult[DataPointsByIdResponse](
+        retryWithExpectedResult[DataPointsByExternalIdResponse](
           dataPoints.queryByExternalId(timeSeriesExternalId, start, end.plusMillis(1)),
           p2 => p2.datapoints should have size testDataPoints.size.toLong
         )
 
-        retryWithExpectedResult[DataPointsByIdResponse](
+        retryWithExpectedResult[DataPointsByExternalIdResponse](
           dataPoints.queryByExternalId(timeSeriesExternalId, start, end.plusMillis(1), Some(5)),
           p2 => p2.datapoints should have size 5
         )
@@ -69,7 +69,7 @@ trait DataPointsResourceBehaviors extends Matchers with RetryWhile { this: FlatS
         )
 
         dataPoints.deleteRangeByExternalId(timeSeriesExternalId, start, end.plusMillis(1))
-        retryWithExpectedResult[DataPointsByIdResponse](
+        retryWithExpectedResult[DataPointsByExternalIdResponse](
           dataPoints.queryByExternalId(timeSeriesExternalId, start, end.plusMillis(1)),
           pad => pad.datapoints should have size 0
         )

--- a/src/test/scala/com/cognite/sdk/scala/common/StringDataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/StringDataPointsResourceBehaviors.scala
@@ -1,8 +1,9 @@
 package com.cognite.sdk.scala.common
 
 import java.time.Instant
+import java.util.UUID
 
-import com.cognite.sdk.scala.v1.{StringDataPointsByIdResponse, TimeSeries}
+import com.cognite.sdk.scala.v1.{StringDataPointsByExternalIdResponse, StringDataPointsByIdResponse, TimeSeries}
 import com.cognite.sdk.scala.v1.resources.DataPointsResource
 import com.softwaremill.sttp.Id
 import org.scalatest.{FlatSpec, Matchers}
@@ -18,16 +19,16 @@ trait StringDataPointsResourceBehaviors extends Matchers with RetryWhile { this:
   def withStringTimeSeries(testCode: TimeSeries => Any): Unit
 
   // scalastyle:off
-  def stringDataPointsResource(dataPoints: DataPointsResource[Id]): Unit =
+  def stringDataPointsResource(dataPoints: DataPointsResource[Id]): Unit = {
     it should "be possible to insert and delete string data points" in withStringTimeSeries {
       stringTimeSeries =>
       val stringTimeSeriesId = stringTimeSeries.id
         val stringTimeSeriesExternalId = stringTimeSeries.externalId.get
         dataPoints.insertStringsById(stringTimeSeriesId, testStringDataPoints)
 
-        retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
+        retryWithExpectedResult[StringDataPointsByIdResponse](
           dataPoints.queryStringsById(stringTimeSeriesId, start, end.plusMillis(1)),
-          p => p.head.datapoints should have size testStringDataPoints.size.toLong
+          p => p.datapoints should have size testStringDataPoints.size.toLong
         )
 
         retryWithExpectedResult[Option[StringDataPoint]](
@@ -39,16 +40,34 @@ trait StringDataPointsResourceBehaviors extends Matchers with RetryWhile { this:
         )
 
         dataPoints.deleteRangeById(stringTimeSeriesId, start, end.plusMillis(1))
-        retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
+        val resultId = retryWithExpectedResult[StringDataPointsByIdResponse](
           dataPoints.queryStringsById(stringTimeSeriesId, start, end.plusMillis(1)),
-          dp => dp.head.datapoints should have size 0
+          dp => dp.datapoints should have size 0
         )
 
+        resultId.externalId shouldBe Some(stringTimeSeriesExternalId)
+        resultId.unit shouldBe stringTimeSeries.unit
+        resultId.isString shouldBe true
+        resultId.id shouldBe stringTimeSeries.id
+
+        val resultId2: Seq[_] = dataPoints.queryStringsByIds(Seq(stringTimeSeriesId), start, end.plusMillis(1))
+        resultId2.length shouldBe 1
+        resultId2.head shouldBe resultId
+
         dataPoints.insertStringsByExternalId(stringTimeSeriesExternalId, testStringDataPoints)
-        retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
+        val resultExternalId: StringDataPointsByExternalIdResponse = retryWithExpectedResult[StringDataPointsByExternalIdResponse](
           dataPoints.queryStringsByExternalId(stringTimeSeriesExternalId, start, end.plusMillis(1)),
-          p2 => p2.head.datapoints should have size testStringDataPoints.size.toLong
+          p2 => p2.datapoints should have size testStringDataPoints.size.toLong
         )
+
+        resultExternalId.externalId shouldBe stringTimeSeriesExternalId
+        resultExternalId.unit shouldBe stringTimeSeries.unit
+        resultExternalId.isString shouldBe true
+        resultExternalId.id shouldBe stringTimeSeries.id
+
+        val resultExternalId2: Seq[StringDataPointsByExternalIdResponse] = dataPoints.queryStringsByExternalIds(Seq(stringTimeSeriesExternalId), start, end.plusMillis(1))
+        resultExternalId2.length shouldBe 1
+        resultExternalId2.head shouldBe resultExternalId
 
         retryWithExpectedResult[Option[StringDataPoint]](
           dataPoints.getLatestStringDataPointByExternalId(stringTimeSeriesExternalId),
@@ -59,9 +78,26 @@ trait StringDataPointsResourceBehaviors extends Matchers with RetryWhile { this:
         )
 
         dataPoints.deleteRangeById(stringTimeSeriesId, start, end.plusMillis(1))
-        retryWithExpectedResult[Seq[StringDataPointsByIdResponse]](
+        retryWithExpectedResult[StringDataPointsByExternalIdResponse](
           dataPoints.queryStringsByExternalId(stringTimeSeriesExternalId, start, end.plusMillis(1)),
-          pad => pad.head.datapoints should have size 0
+          pad => pad.datapoints should have size 0
         )
     }
+
+    it should "support support query by externalId when ignoreUnknownIds=true" in {
+      val doesNotExist = "does-not-exist-" + UUID.randomUUID
+      dataPoints.getLatestStringDataPointByExternalIds(Seq(doesNotExist), ignoreUnknownIds = true) shouldBe empty
+      dataPoints.getLatestDataPointsByExternalIds(Seq(doesNotExist), ignoreUnknownIds = true) shouldBe empty
+      dataPoints.queryByExternalIds(Seq(doesNotExist), Instant.EPOCH, Instant.now, ignoreUnknownIds = true) shouldBe empty
+      dataPoints.queryStringsByExternalIds(Seq(doesNotExist), Instant.EPOCH, Instant.now, ignoreUnknownIds = true) shouldBe empty
+    }
+
+    it should "support support query by internal id when ignoreUnknownIds=true" in {
+      val doesNotExist = 9007199254740991L
+      dataPoints.getLatestStringDataPointByIds(Seq(doesNotExist), ignoreUnknownIds = true) shouldBe empty
+      dataPoints.getLatestDataPointsByIds(Seq(doesNotExist), ignoreUnknownIds = true) shouldBe empty
+      dataPoints.queryByIds(Seq(doesNotExist), Instant.EPOCH, Instant.now, ignoreUnknownIds = true) shouldBe empty
+      dataPoints.queryStringsByIds(Seq(doesNotExist), Instant.EPOCH, Instant.now, ignoreUnknownIds = true) shouldBe empty
+    }
+  }
 }


### PR DESCRIPTION
* Adds support for ignoreUnknownIds when fetching datapoints
* Uses DataPointsByExternalIdResponse and DataPointsByIdResponse consistently
* strings by a single id return single response
* empty externalIds unit are treated as `null` (because protobuf..)