### PR TITLE
Change Client parameters order, remove unused streaming type

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -152,9 +152,9 @@ final case class RequestSession[F[_]: Monad](
 class GenericClient[F[_]: Monad, S](
     applicationName: String,
     val projectName: String,
-    auth: Auth,
     baseUrl: String =
-      Option(System.getenv("COGNITE_BASE_URL")).getOrElse("https://api.cognitedata.com")
+      Option(System.getenv("COGNITE_BASE_URL")).getOrElse("https://api.cognitedata.com"),
+    auth: Auth = Auth.defaultAuth
 )(
     implicit sttpBackend: SttpBackend[F, S]
 ) {
@@ -239,7 +239,7 @@ object GenericClient {
       if (projectName.trim.isEmpty) {
         throw InvalidAuthentication()
       } else {
-        new GenericClient[F, S](applicationName, projectName, auth, baseUrl)(
+        new GenericClient[F, S](applicationName, projectName, baseUrl, auth)(
           implicitly,
           sttpBackend
         )
@@ -250,9 +250,9 @@ object GenericClient {
 final case class Client(
     applicationName: String,
     override val projectName: String,
-    auth: Auth = Auth.defaultAuth,
     baseUrl: String =
-      Option(System.getenv("COGNITE_BASE_URL")).getOrElse("https://api.cognitedata.com")
+      Option(System.getenv("COGNITE_BASE_URL")).getOrElse("https://api.cognitedata.com"),
+    auth: Auth = Auth.defaultAuth
 )(
     implicit sttpBackend: SttpBackend[Id, Nothing]
-) extends GenericClient[Id, Nothing](applicationName, projectName, auth, baseUrl)
+) extends GenericClient[Id, Nothing](applicationName, projectName, baseUrl, auth)

--- a/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
@@ -38,8 +38,8 @@ class FilterTest extends SdkTestSpec {
     })
     lazy val dummyClient = Client("foo",
       projectName,
-      auth,
-      "https://api.cognitedata.com")(requestHijacker)
+      "https://api.cognitedata.com",
+      auth)(requestHijacker)
     val dummyRequestSession = dummyClient.requestSession
 
     Filter.filterWithCursor(

--- a/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
@@ -30,8 +30,8 @@ class ReadTest extends SdkTestSpec {
     })
     lazy val dummyClient = Client("foo",
       projectName,
-      auth,
-      "https://api.cognitedata.com")(requestHijacker)
+      "https://api.cognitedata.com",
+      auth)(requestHijacker)
     val dummyRequestSession = dummyClient.requestSession
 
     Readable.readWithCursor(

--- a/src/test/scala/com/cognite/sdk/scala/common/SdkTestSpec.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/SdkTestSpec.scala
@@ -38,10 +38,10 @@ class LoggingSttpBackend[R[_], S](delegate: SttpBackend[R, S]) extends SttpBacke
 
 abstract class SdkTestSpec extends FlatSpec with Matchers {
   // Use this if you need request logs for debugging: new LoggingSttpBackend[Id, Nothing](sttpBackend)
-  lazy val client: GenericClient[Id, Nothing] = GenericClient.forAuth[Id, Nothing](
+  lazy val client: GenericClient[Id] = GenericClient.forAuth[Id](
     "scala-sdk-test", auth)(implicitly, sttpBackend)
 
-  lazy val greenfieldClient: GenericClient[Id, Nothing] = GenericClient.forAuth[Id, Nothing](
+  lazy val greenfieldClient: GenericClient[Id] = GenericClient.forAuth[Id](
     "scala-sdk-test", greenfieldAuth, "https://greenfield.cognitedata.com")(implicitly, sttpBackend)
 
   lazy val projectName: String = client.login.status().project

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -18,12 +18,12 @@ import scala.concurrent.duration._
 
 class ClientTest extends SdkTestSpec {
   "Client" should "fetch the project using login/status if necessary" in {
-    noException should be thrownBy GenericClient.forAuth[Id, Nothing](
+    noException should be thrownBy GenericClient.forAuth[Id](
       "scala-sdk-test", auth)(
       implicitly,
       sttpBackend
     )
-    GenericClient.forAuth[Id, Nothing]("scala-sdk-test", auth)(
+    GenericClient.forAuth[Id]("scala-sdk-test", auth)(
       implicitly,
       sttpBackend
     ).projectName should not be empty
@@ -47,7 +47,7 @@ class ClientTest extends SdkTestSpec {
     val respondWithoutApiKeyId = SttpBackendStub.synchronous
       .whenAnyRequest
       .thenRespond(loginStatusResponseWithoutApiKeyId)
-    new GenericClient[Id, Nothing](
+    new GenericClient[Id](
       "scala-sdk-test", projectName, auth = auth)(
       implicitly,
       respondWithoutApiKeyId
@@ -72,7 +72,7 @@ class ClientTest extends SdkTestSpec {
     val respondWithApiKeyId = SttpBackendStub.synchronous
       .whenAnyRequest
       .thenRespond(loginStatusResponseWithApiKeyId)
-    new GenericClient[Id, Nothing](
+    new GenericClient[Id](
       "scala-sdk-test", projectName, auth = auth)(
       implicitly,
       respondWithApiKeyId
@@ -82,7 +82,7 @@ class ClientTest extends SdkTestSpec {
   it should "support async IO clients" in {
     implicit val contextShift: ContextShift[IO] = IO.contextShift(ExecutionContext.global)
     implicit val timer: Timer[IO] = IO.timer(ExecutionContext.global)
-    GenericClient.forAuth[IO, Nothing]("scala-sdk-test", auth)(
+    GenericClient.forAuth[IO]("scala-sdk-test", auth)(
       implicitly,
       new RetryingBackend[IO, Nothing](AsyncHttpClientCatsBackend[IO]())
     ).unsafeRunSync().projectName should not be empty
@@ -90,7 +90,7 @@ class ClientTest extends SdkTestSpec {
 
   it should "throw an exception if the authentication is invalid and project is not specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key")
-    an[InvalidAuthentication] should be thrownBy GenericClient.forAuth[Id, Nothing](
+    an[InvalidAuthentication] should be thrownBy GenericClient.forAuth[Id](
       "scala-sdk-test", auth)(
       implicitly,
       sttpBackend
@@ -99,7 +99,7 @@ class ClientTest extends SdkTestSpec {
 
   it should "not throw an exception if the authentication is invalid and project is specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key", project = Some("random-project"))
-    noException should be thrownBy new GenericClient[Id, Nothing](
+    noException should be thrownBy new GenericClient[Id](
       "scala-sdk-test", projectName, auth = auth)(
       implicitly,
       sttpBackend
@@ -109,7 +109,7 @@ class ClientTest extends SdkTestSpec {
   it should "be possible to use the sdk with greenfield.cognite.data.com" in {
     implicit val auth: Auth = ApiKeyAuth(Option(System.getenv("TEST_API_KEY_GREENFIELD"))
       .getOrElse(throw new RuntimeException("TEST_API_KEY_GREENFIELD not set")))
-    noException should be thrownBy new GenericClient[Id, Nothing](
+    noException should be thrownBy new GenericClient[Id](
       "cdp-spark-datasource-test",
       projectName,
       "https://greenfield.cognitedata.com",
@@ -175,13 +175,13 @@ class ClientTest extends SdkTestSpec {
 
   it should "retry certain failed requests" in {
     assertThrows[CdpApiException] {
-      GenericClient.forAuth[Id, Nothing]("scala-sdk-test", auth)(
+      GenericClient.forAuth[Id]("scala-sdk-test", auth)(
         implicitly,
         makeTestingBackend()
       ).threeDModels.list()
     }
 
-    val _ = GenericClient.forAuth[Id, Nothing]("scala-sdk-test", auth)(
+    val _ = GenericClient.forAuth[Id]("scala-sdk-test", auth)(
       implicitly,
       new RetryingBackend[Id, Nothing](
         makeTestingBackend(),
@@ -190,7 +190,7 @@ class ClientTest extends SdkTestSpec {
     ).threeDModels.list()
 
     assertThrows[CdpApiException] {
-      GenericClient.forAuth[Id, Nothing]("scala-sdk-test", auth)(
+      GenericClient.forAuth[Id]("scala-sdk-test", auth)(
         implicitly,
         new RetryingBackend[Id, Nothing](
           makeTestingBackend(),
@@ -218,7 +218,7 @@ class ClientTest extends SdkTestSpec {
         unavailableResponse,
         serverError,
         loginStatusResponse)
-    val client = new GenericClient[Id, Nothing]("scala-sdk-test",
+    val client = new GenericClient[Id]("scala-sdk-test",
       projectName,
       "https://www.cognite.com/nowhereatall",
       ApiKeyAuth("irrelevant", Some("randomproject"))
@@ -278,7 +278,7 @@ class ClientTest extends SdkTestSpec {
         badRequest,
         assetsResponse
       )
-    val client = new GenericClient[Id, Nothing]("scala-sdk-test",
+    val client = new GenericClient[Id]("scala-sdk-test",
       projectName,
       "https://www.cognite1999.com/nowhere-at-all",
       ApiKeyAuth("irrelevant", Some("randomproject"))
@@ -316,7 +316,7 @@ class ClientTest extends SdkTestSpec {
         serverErrorHtmlBytes,
         badRequestBytes,
         protobufResponse)
-    val client2 = new GenericClient[Id, Nothing]("scala-sdk-test",
+    val client2 = new GenericClient[Id]("scala-sdk-test",
       projectName,
       "https://www.cognite1999.com/nowhere-at-all",
       ApiKeyAuth("irrelevant", Some("randomproject"))

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -48,7 +48,7 @@ class ClientTest extends SdkTestSpec {
       .whenAnyRequest
       .thenRespond(loginStatusResponseWithoutApiKeyId)
     new GenericClient[Id, Nothing](
-      "scala-sdk-test", projectName, auth)(
+      "scala-sdk-test", projectName, auth = auth)(
       implicitly,
       respondWithoutApiKeyId
     ).login.status().apiKeyId shouldBe empty
@@ -73,7 +73,7 @@ class ClientTest extends SdkTestSpec {
       .whenAnyRequest
       .thenRespond(loginStatusResponseWithApiKeyId)
     new GenericClient[Id, Nothing](
-      "scala-sdk-test", projectName, auth)(
+      "scala-sdk-test", projectName, auth = auth)(
       implicitly,
       respondWithApiKeyId
     ).login.status().apiKeyId shouldBe Some(12147483647L)
@@ -100,7 +100,7 @@ class ClientTest extends SdkTestSpec {
   it should "not throw an exception if the authentication is invalid and project is specified" in {
     implicit val auth: Auth = ApiKeyAuth("invalid-key", project = Some("random-project"))
     noException should be thrownBy new GenericClient[Id, Nothing](
-      "scala-sdk-test", projectName, auth)(
+      "scala-sdk-test", projectName, auth = auth)(
       implicitly,
       sttpBackend
     )
@@ -112,8 +112,8 @@ class ClientTest extends SdkTestSpec {
     noException should be thrownBy new GenericClient[Id, Nothing](
       "cdp-spark-datasource-test",
       projectName,
-      auth,
-      "https://greenfield.cognitedata.com"
+      "https://greenfield.cognitedata.com",
+      auth
     )(implicitly,
       sttpBackend
     )
@@ -124,24 +124,24 @@ class ClientTest extends SdkTestSpec {
       Client(
         "relationships-unit-tests",
         projectName,
-        auth,
-        ""
+        "",
+        auth
       )(new LoggingSttpBackend[Id, Nothing](sttpBackend)).login.status()
     }
     assertThrows[SdkException] {
       Client(
         "url-test-2",
         projectName,
-        auth,
-        "api.cognitedata.com"
+        "api.cognitedata.com",
+        auth
       )(sttpBackend).login.status()
     }
     assertThrows[UnknownHostException] {
       Client(
         "url-test-3",
         projectName,
-        auth,
-        "thisShouldThrowAnUnknownHostException:)"
+        "thisShouldThrowAnUnknownHostException:)",
+        auth
       )(sttpBackend).login.status()
     }
   }
@@ -220,8 +220,9 @@ class ClientTest extends SdkTestSpec {
         loginStatusResponse)
     val client = new GenericClient[Id, Nothing]("scala-sdk-test",
       projectName,
-      ApiKeyAuth("irrelevant", Some("randomproject")),
-      "https://www.cognite.com/nowhereatall"
+      "https://www.cognite.com/nowhereatall",
+      ApiKeyAuth("irrelevant", Some("randomproject"))
+
     )(
       implicitly,
       new RetryingBackend[Id, Nothing](backendStub,
@@ -279,8 +280,8 @@ class ClientTest extends SdkTestSpec {
       )
     val client = new GenericClient[Id, Nothing]("scala-sdk-test",
       projectName,
-      ApiKeyAuth("irrelevant", Some("randomproject")),
-      "https://www.cognite1999.com/nowhere-at-all"
+      "https://www.cognite1999.com/nowhere-at-all",
+      ApiKeyAuth("irrelevant", Some("randomproject"))
     )(
       implicitly,
       new RetryingBackend[Id, Nothing](
@@ -317,8 +318,8 @@ class ClientTest extends SdkTestSpec {
         protobufResponse)
     val client2 = new GenericClient[Id, Nothing]("scala-sdk-test",
       projectName,
-      ApiKeyAuth("irrelevant", Some("randomproject")),
-      "https://www.cognite1999.com/nowhere-at-all"
+      "https://www.cognite1999.com/nowhere-at-all",
+      ApiKeyAuth("irrelevant", Some("randomproject"))
     )(
       implicitly,
       new RetryingBackend[Id, Nothing](


### PR DESCRIPTION
After using this for a while I've found it far more common to want to
change the baseUrl than the auth, so it's much nicer to be able to
just do
`val c = new Client("asdf", "wjoel", "https://greenfield.cognitedata.com")`

instead of
`val c = new Client("asdf", "wjoel", Auth.defaultAuth, "https://greenfield.cognitedata.com")`

or
`val c = new Client("asdf", "wjoel", baseUrl = "https://greenfield.cognitedata.com")`

Even better when the Client has an apply method.