### PR TITLE
Refactor Auth interface as a middleware function

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/auth.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/auth.scala
@@ -3,13 +3,30 @@
 
 package com.cognite.sdk.scala.common
 
-import com.softwaremill.sttp.RequestT
+import com.softwaremill.sttp.{MonadError, Request, RequestT, Response, SttpBackend}
 
 final case class InvalidAuthentication() extends Throwable(s"Invalid authentication")
 
 sealed trait Auth {
   val project: Option[String] = None
+  def middleware[F[_], S](backend: SttpBackend[F, S]): SttpBackend[F, S]
+}
+
+/** For simple authentication schemes that only apply a pure function to the request. */
+sealed trait PureAuth extends Auth {
   def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S]
+
+  final override def middleware[F[_], S](delegate: SttpBackend[F, S]): SttpBackend[F, S] =
+    new SttpBackend[F, S] {
+      override def send[T](request: Request[T, S]): F[Response[T]] =
+        delegate.send(auth(request))
+
+      override def close(): Unit =
+        delegate.close()
+
+      override def responseMonad: MonadError[F] =
+        delegate.responseMonad
+    }
 }
 
 object Auth {
@@ -18,14 +35,9 @@ object Auth {
     Option(System.getenv(apiKeyEnvironmentVariable))
       .map(ApiKeyAuth(_, None))
       .getOrElse[Auth](NoAuthentication())
-
-  implicit class AuthSttpExtension[U[_], T, +S](val r: RequestT[U, T, S]) {
-    def auth(auth: Auth): RequestT[U, T, S] =
-      auth.auth(r)
-  }
 }
 
-final case class NoAuthentication() extends Auth {
+final case class NoAuthentication() extends PureAuth {
   def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S] =
     throw new SdkException(
       s"Authentication not provided and environment variable ${Auth.apiKeyEnvironmentVariable} not set"
@@ -33,19 +45,19 @@ final case class NoAuthentication() extends Auth {
 }
 
 final case class ApiKeyAuth(apiKey: String, override val project: Option[String] = None)
-    extends Auth {
+    extends PureAuth {
   def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S] =
     r.header("api-key", apiKey)
 }
 
 final case class BearerTokenAuth(bearerToken: String, override val project: Option[String] = None)
-    extends Auth {
+    extends PureAuth {
   def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S] =
     r.header("Authorization", s"Bearer $bearerToken")
 }
 
 final case class TicketAuth(authTicket: String, override val project: Option[String] = None)
-    extends Auth {
+    extends PureAuth {
   def auth[U[_], T, S](r: RequestT[U, T, S]): RequestT[U, T, S] =
     r.header("auth-ticket", authTicket)
 }

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
@@ -62,7 +62,6 @@ class DataPointsResource[F[_]: Monad](val requestSession: RequestSession[F])
     requestSession.map(
       sttp
         .followRedirects(false)
-        .auth(requestSession.auth)
         .contentType("application/protobuf")
         .header("accept", "application/json")
         .header("x-cdp-sdk", s"${BuildInfo.organization}-${BuildInfo.version}")
@@ -109,7 +108,6 @@ class DataPointsResource[F[_]: Monad](val requestSession: RequestSession[F])
     requestSession.map(
       sttp
         .followRedirects(false)
-        .auth(requestSession.auth)
         .contentType("application/protobuf")
         .header("accept", "application/json")
         .header("x-cdp-sdk", s"${BuildInfo.organization}-${BuildInfo.version}")


### PR DESCRIPTION
This extends the capabilities of the Auth trait by defining it in terms of a middleware function from SttpBackend => SttpBackend.
It also includes a convenience implementation (PureAuth) for the majority of auth schemes which only need to apply a pure function to the request.

This is the first step in introducing support for authentication schemes that require a network call every once in a while, i.e. OAuth2.