### PR TITLE
Revert "Update sbt-protoc to 0.99.34"

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,10 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.7"
 addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.204")
+
+// Warning: These must be synced with
+// https://github.com/cognitedata/cdp-spark-datasource/blob/master/project/protoc.sbt
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31") // See warning above
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.7" // See warning above
+

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,6 +6,6 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.1")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.13")
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.34")
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31")
 libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.7"
 addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.204")


### PR DESCRIPTION
Reverts cognitedata/cognite-sdk-scala#212

The changes don't seem to be very useful, and we'd have to update https://github.com/cognitedata/cdp-spark-datasource/blob/master/project/protoc.sbt along with a new release over there.

Looks like a v1 release is on the way, which would hopefully make this a non-issue.