### PR TITLE
Add support for Scala 3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,6 +124,7 @@ lazy val core = (project in file("."))
           // We use JavaConverters to remain backwards compatible with Scala 2.11
           "-Wconf:cat=deprecation:i"
         )
+      case Some((3, _)) => List("-source:3.0-migration")
       case _ =>
         List.empty[String]
     }),
@@ -180,6 +181,14 @@ scalacOptions --= (CrossVersion.partialVersion(scalaVersion.value) match {
   case _ =>
     List.empty[String]
 })
+
+// Filter out "-source future" on Scala 3, as we need Scala 2.13 compatibility.
+// This will no longer be necessary once we upgrade to a version that includes
+// https://github.com/DavidGregory084/sbt-tpolecat/pull/44
+val filterOutSourceFuture = { options: Seq[String] =>
+  options.filterNot(Set("-source", "future"))
+}
+scalacOptions ~= filterOutSourceFuture
 
 scalastyleFailOnWarning := true
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -8,8 +8,7 @@ addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.8.2")
 addSbtPlugin("au.com.onegeek" %% "sbt-dotenv" % "2.1.233")
 addSbtPlugin("org.wartremover" % "sbt-wartremover" % "2.4.15")
 
-
 // Warning: These must be synced with
 // https://github.com/cognitedata/cdp-spark-datasource/blob/master/project/protoc.sbt
-addSbtPlugin("com.thesamet" % "sbt-protoc" % "0.99.31") // See warning above
-libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.9.7" // See warning above
+addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.0") // See warning above
+libraryDependencies += "com.thesamet.scalapb" %% "compilerplugin" % "0.11.3"

--- a/src/main/scala/com/cognite/sdk/scala/common/ReadableResource.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/ReadableResource.scala
@@ -148,7 +148,7 @@ object RetrieveByIds {
       implicit itemsDecoder: Decoder[Items[R]]
   ): F[Seq[R]] =
     requestSession.post[Seq[R], Items[R], Items[CogniteInternalId]](
-      Items(ids.map(CogniteInternalId)),
+      Items(ids.map(CogniteInternalId.apply)),
       uri"$baseUrl/byids",
       value => value.items
     )
@@ -168,7 +168,7 @@ object RetrieveByIdsWithIgnoreUnknownIds {
       ignoreUnknownIds: Boolean
   )(implicit itemsDecoder: Decoder[Items[R]]): F[Seq[R]] =
     requestSession.post[Seq[R], Items[R], ItemsWithIgnoreUnknownIds[CogniteId]](
-      ItemsWithIgnoreUnknownIds(ids.map(CogniteInternalId), ignoreUnknownIds),
+      ItemsWithIgnoreUnknownIds(ids.map(CogniteInternalId.apply), ignoreUnknownIds),
       uri"$baseUrl/byids",
       value => value.items
     )
@@ -190,7 +190,7 @@ object RetrieveByExternalIds {
       externalIds: Seq[String]
   )(implicit itemsDecoder: Decoder[Items[R]]): F[Seq[R]] =
     requestSession.post[Seq[R], Items[R], Items[CogniteExternalId]](
-      Items(externalIds.map(CogniteExternalId)),
+      Items(externalIds.map(CogniteExternalId.apply)),
       uri"$baseUrl/byids",
       value => value.items
     )
@@ -210,7 +210,7 @@ object RetrieveByExternalIdsWithIgnoreUnknownIds {
       ignoreUnknownIds: Boolean
   )(implicit itemsDecoder: Decoder[Items[R]]): F[Seq[R]] =
     requestSession.post[Seq[R], Items[R], ItemsWithIgnoreUnknownIds[CogniteId]](
-      ItemsWithIgnoreUnknownIds(externalIds.map(CogniteExternalId), ignoreUnknownIds),
+      ItemsWithIgnoreUnknownIds(externalIds.map(CogniteExternalId.apply), ignoreUnknownIds),
       uri"$baseUrl/byids",
       value => value.items
     )

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -6,6 +6,7 @@ package com.cognite.sdk.scala.v1
 import BuildInfo.BuildInfo
 import cats.{Id, Monad}
 import cats.implicits._
+import cats.catsInstancesForId
 import com.cognite.sdk.scala.common._
 import com.cognite.sdk.scala.v1.resources._
 import sttp.client3._
@@ -23,7 +24,7 @@ import scala.util.control.NonFatal
 class AuthSttpBackend[F[_], +P](delegate: SttpBackend[F, P], authProvider: AuthProvider[F])
     extends SttpBackend[F, P] {
   override def send[T, R >: P with Effect[F]](request: Request[T, R]): F[Response[T]] =
-    responseMonad.flatMap(authProvider.getAuth) { auth: Auth =>
+    responseMonad.flatMap(authProvider.getAuth) { (auth: Auth) =>
       delegate.send(auth.auth(request))
     }
 

--- a/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/assets.scala
@@ -24,6 +24,34 @@ final case class Asset(
 ) extends WithId[Long]
     with WithExternalId
     with WithCreatedTime
+    with ToCreate[AssetCreate]
+    with ToUpdate[AssetUpdate] {
+  override def toCreate: AssetCreate =
+    AssetCreate(
+      name,
+      parentId,
+      description,
+      source,
+      externalId,
+      metadata,
+      parentExternalId,
+      dataSetId,
+      labels
+    )
+
+  override def toUpdate: AssetUpdate =
+    AssetUpdate(
+      Some(NonNullableSetter.fromAny(name)),
+      Setter.fromOption(description),
+      Setter.fromOption(source),
+      Setter.fromOption(externalId),
+      NonNullableSetter.fromOption(metadata),
+      Setter.fromOption(parentId),
+      Setter.fromOption(parentExternalId),
+      Setter.fromOption(dataSetId),
+      labels.map(ls => LabelsOnUpdate(Some(ls), None))
+    )
+}
 
 final case class AssetCreate(
     name: String,

--- a/src/main/scala/com/cognite/sdk/scala/v1/dataSets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataSets.scala
@@ -19,6 +19,26 @@ final case class DataSet(
 ) extends WithId[Long]
     with WithExternalId
     with WithCreatedTime
+    with ToCreate[DataSetCreate]
+    with ToUpdate[DataSetUpdate] {
+  override def toCreate: DataSetCreate =
+    DataSetCreate(
+      externalId,
+      name,
+      description,
+      metadata,
+      writeProtected
+    )
+
+  override def toUpdate: DataSetUpdate =
+    DataSetUpdate(
+      Setter.fromOption(externalId),
+      Setter.fromOption(name),
+      Setter.fromOption(description),
+      NonNullableSetter.fromOption(metadata),
+      Some(NonNullableSetter.fromAny(writeProtected))
+    )
+}
 
 final case class DataSetCreate(
     externalId: Option[String] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/events.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/events.scala
@@ -23,6 +23,36 @@ final case class Event(
 ) extends WithId[Long]
     with WithExternalId
     with WithCreatedTime
+    with ToCreate[EventCreate]
+    with ToUpdate[EventUpdate] {
+  override def toCreate: EventCreate =
+    EventCreate(
+      startTime,
+      endTime,
+      description,
+      `type`,
+      subtype,
+      metadata,
+      assetIds,
+      source,
+      externalId,
+      dataSetId
+    )
+
+  override def toUpdate: EventUpdate =
+    EventUpdate(
+      Setter.fromOption(startTime),
+      Setter.fromOption(endTime),
+      Setter.fromOption(description),
+      Setter.fromOption(`type`),
+      Setter.fromOption(subtype),
+      NonNullableSetter.fromOption(metadata),
+      NonNullableSetter.fromOption(assetIds),
+      Setter.fromOption(source),
+      Setter.fromOption(externalId),
+      Setter.fromOption(dataSetId)
+    )
+}
 
 final case class EventCreate(
     startTime: Option[Instant] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/files.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/files.scala
@@ -4,11 +4,12 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
 import com.cognite.sdk.scala.common.{
   NonNullableSetter,
   SearchQuery,
   Setter,
+  ToCreate,
+  ToUpdate,
   WithCreatedTime,
   WithExternalId,
   WithId,
@@ -35,6 +36,35 @@ final case class File(
 ) extends WithId[Long]
     with WithExternalId
     with WithCreatedTime
+    with ToCreate[FileCreate]
+    with ToUpdate[FileUpdate] {
+  override def toCreate: FileCreate =
+    FileCreate(
+      name,
+      source,
+      externalId,
+      mimeType,
+      metadata,
+      assetIds,
+      dataSetId,
+      sourceCreatedTime,
+      sourceModifiedTime,
+      securityCategories
+    )
+
+  override def toUpdate: FileUpdate =
+    FileUpdate(
+      Setter.fromOption(externalId),
+      Setter.fromOption(source),
+      Setter.fromOption(mimeType),
+      NonNullableSetter.fromOption(metadata),
+      NonNullableSetter.fromOption(assetIds),
+      Setter.fromOption(sourceCreatedTime),
+      Setter.fromOption(sourceModifiedTime),
+      NonNullableSetter.fromOption(securityCategories),
+      Setter.fromOption(dataSetId)
+    )
+}
 
 final case class FileCreate(
     name: String,

--- a/src/main/scala/com/cognite/sdk/scala/v1/functions.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/functions.scala
@@ -24,7 +24,19 @@ final case class Function(
     status: Option[String] = None,
     externalId: Option[String] = None,
     error: Option[FunctionError] = None
-)
+) extends ToCreate[FunctionCreate] {
+  override def toCreate: FunctionCreate =
+    FunctionCreate(
+      name,
+      fileId,
+      owner,
+      description,
+      apiKey,
+      secrets,
+      externalId,
+      error
+    )
+}
 
 final case class FunctionCreate(
     name: String = "",
@@ -72,7 +84,16 @@ final case class FunctionSchedule(
     description: Option[String] = None,
     cronExpression: Option[String] = None,
     data: Option[Json] = None
-)
+) extends ToCreate[FunctionScheduleCreate] {
+  override def toCreate: FunctionScheduleCreate =
+    FunctionScheduleCreate(
+      name,
+      functionExternalId,
+      description,
+      cronExpression.getOrElse(""),
+      data
+    )
+}
 
 final case class FunctionScheduleCreate(
     name: String = "",

--- a/src/main/scala/com/cognite/sdk/scala/v1/labels.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/labels.scala
@@ -13,6 +13,14 @@ final case class Label(
     createdTime: Instant = Instant.ofEpochMilli(0)
 ) extends WithRequiredExternalId
     with WithCreatedTime
+    with ToCreate[LabelCreate] {
+  override def toCreate: LabelCreate =
+    LabelCreate(
+      externalId,
+      name,
+      description
+    )
+}
 
 final case class LabelCreate(
     externalId: String,

--- a/src/main/scala/com/cognite/sdk/scala/v1/raw.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/raw.scala
@@ -4,23 +4,28 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
-import com.cognite.sdk.scala.common.WithId
+import com.cognite.sdk.scala.common.{ToCreate, WithId}
 import io.circe.Json
 
-final case class RawDatabase(name: String) extends WithId[String] {
+final case class RawDatabase(name: String) extends WithId[String] with ToCreate[RawDatabase] {
   override val id: String = this.name
+
+  override def toCreate: RawDatabase = this
 }
 
-final case class RawTable(name: String) extends WithId[String] {
+final case class RawTable(name: String) extends WithId[String] with ToCreate[RawTable] {
   override val id: String = this.name
+
+  override def toCreate: RawTable = this
 }
 
 final case class RawRow(
     key: String,
     columns: Map[String, Json],
     lastUpdatedTime: Option[Instant] = None
-)
+) extends ToCreate[RawRow] {
+  override def toCreate: RawRow = this
+}
 
 final case class RawRowKey(key: String)
 

--- a/src/main/scala/com/cognite/sdk/scala/v1/relationships.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/relationships.scala
@@ -21,6 +21,21 @@ final case class Relationship(
     lastUpdatedTime: Instant = Instant.ofEpochMilli(0)
 ) extends WithRequiredExternalId
     with WithCreatedTime
+    with ToCreate[RelationshipCreate] {
+  override def toCreate: RelationshipCreate =
+    RelationshipCreate(
+      externalId,
+      sourceExternalId,
+      sourceType,
+      targetExternalId,
+      targetType,
+      startTime,
+      endTime,
+      confidence,
+      dataSetId,
+      labels
+    )
+}
 
 final case class RelationshipCreate(
     externalId: String,

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/assets.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/assets.scala
@@ -86,7 +86,7 @@ class Assets[F[_]](val requestSession: RequestSession[F])
   ): F[Unit] =
     requestSession.post[Unit, Unit, ItemsWithRecursiveAndIgnoreUnknownIds](
       ItemsWithRecursiveAndIgnoreUnknownIds(
-        ids.map(CogniteInternalId),
+        ids.map(CogniteInternalId.apply),
         recursive,
         ignoreUnknownIds
       ),
@@ -112,7 +112,7 @@ class Assets[F[_]](val requestSession: RequestSession[F])
   ): F[Unit] =
     requestSession.post[Unit, Unit, ItemsWithRecursiveAndIgnoreUnknownIds](
       ItemsWithRecursiveAndIgnoreUnknownIds(
-        externalIds.map(CogniteExternalId),
+        externalIds.map(CogniteExternalId.apply),
         recursive,
         ignoreUnknownIds
       ),

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
@@ -30,7 +30,7 @@ class DataPointsResource[F[_]](val requestSession: RequestSession[F])
 
   override val baseUrl = uri"${requestSession.baseUrl}/timeseries/data"
 
-  private def protoNumericDataPoints(dataPoints: Seq[DataPoint]) =
+  private def protoNumericDataPoints(dataPoints: Seq[DataPoint]): NumericDatapoints.Builder =
     NumericDatapoints
       .newBuilder()
       .addAllDatapoints(dataPoints.map { dp =>
@@ -41,7 +41,7 @@ class DataPointsResource[F[_]](val requestSession: RequestSession[F])
           .build()
       }.asJava)
 
-  private def protoStringDataPoints(dataPoints: Seq[StringDataPoint]) =
+  private def protoStringDataPoints(dataPoints: Seq[StringDataPoint]): StringDatapoints.Builder =
     StringDatapoints
       .newBuilder()
       .addAllDatapoints(dataPoints.map { dp =>

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/dataPoints.scala
@@ -614,7 +614,7 @@ object DataPointsResource {
           optionalString(x.getUnit),
           x.getStringDatapoints.getDatapointsList.asScala
             .map(s => StringDataPoint(Instant.ofEpochMilli(s.getTimestamp), s.getValue))
-            .toSeq
+            .toSeq // Required by Scala 2.13 and later, to make this immutable
         )
       )
       .toSeq
@@ -631,7 +631,7 @@ object DataPointsResource {
           optionalString(x.getUnit),
           x.getStringDatapoints.getDatapointsList.asScala
             .map(s => StringDataPoint(Instant.ofEpochMilli(s.getTimestamp), s.getValue))
-            .toSeq
+            .toSeq // Required by Scala 2.13 and later, to make this immutable
         )
       )
       .toSeq
@@ -646,7 +646,7 @@ object DataPointsResource {
         optionalString(x.getUnit),
         x.getNumericDatapoints.getDatapointsList.asScala
           .map(n => DataPoint(Instant.ofEpochMilli(n.getTimestamp), n.getValue))
-          .toSeq
+          .toSeq // Required by Scala 2.13 and later, to make this immutable
       )
     }.toSeq
 
@@ -662,7 +662,7 @@ object DataPointsResource {
         optionalString(x.getUnit),
         x.getNumericDatapoints.getDatapointsList.asScala
           .map(n => DataPoint(Instant.ofEpochMilli(n.getTimestamp), n.getValue))
-          .toSeq
+          .toSeq // Required by Scala 2.13 and later, to make this immutable
       )
     }.toSeq
 
@@ -694,7 +694,7 @@ object DataPointsResource {
                 screenOutNan(a.getDiscreteVariance)
               )
             )
-            .toSeq
+            .toSeq // Required by Scala 2.13 and later, to make this immutable
         )
       )
       .toSeq

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/raw.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/raw.scala
@@ -51,7 +51,7 @@ class RawDatabases[F[_]](val requestSession: RequestSession[F])
     Create.createItems[F, RawDatabase, RawDatabase](requestSession, baseUrl, items)
 
   override def deleteByIds(ids: Seq[String]): F[Unit] =
-    RawResource.deleteByIds(requestSession, baseUrl, ids.map(RawDatabase))
+    RawResource.deleteByIds(requestSession, baseUrl, ids.map(RawDatabase.apply))
 }
 
 object RawDatabases {
@@ -92,7 +92,7 @@ class RawTables[F[_]](val requestSession: RequestSession[F], database: String)
     Create.createItems[F, RawTable, RawTable](requestSession, baseUrl, items)
 
   override def deleteByIds(ids: Seq[String]): F[Unit] =
-    RawResource.deleteByIds(requestSession, baseUrl, ids.map(RawTable))
+    RawResource.deleteByIds(requestSession, baseUrl, ids.map(RawTable.apply))
 }
 
 object RawTables {
@@ -146,7 +146,7 @@ class RawRows[F[_]](val requestSession: RequestSession[F], database: String, tab
     Readable.readWithCursor(requestSession, baseUrl, cursor, limit, None, Constants.rowsBatchSize)
 
   override def deleteByIds(ids: Seq[String]): F[Unit] =
-    RawResource.deleteByIds(requestSession, baseUrl, ids.map(RawRowKey))
+    RawResource.deleteByIds(requestSession, baseUrl, ids.map(RawRowKey.apply))
 
   override private[sdk] def filterWithCursor(
       filter: RawRowFilter,

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/threeD.scala
@@ -27,7 +27,7 @@ class ThreeDModels[F[_]](val requestSession: RequestSession[F])
     //       or assert that length of `ids` is less than max deletion request size
     requestSession
       .post[Unit, Unit, Items[CogniteInternalId]](
-        Items(ids.map(CogniteInternalId)),
+        Items(ids.map(CogniteInternalId.apply)),
         uri"$baseUrl/delete",
         _ => ()
       )
@@ -156,7 +156,7 @@ class ThreeDRevisions[F[_]: Applicative](val requestSession: RequestSession[F], 
     //       or assert that length of `ids` is less than max deletion request size
     requestSession
       .post[Unit, Unit, Items[CogniteInternalId]](
-        Items(ids.map(CogniteInternalId)),
+        Items(ids.map(CogniteInternalId.apply)),
         uri"$baseUrl/delete",
         _ => ()
       )

--- a/src/main/scala/com/cognite/sdk/scala/v1/sequences.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/sequences.scala
@@ -4,12 +4,13 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
 import cats.data.NonEmptyList
 import com.cognite.sdk.scala.common.{
   NonNullableSetter,
   SearchQuery,
   Setter,
+  ToCreate,
+  ToUpdate,
   WithCreatedTime,
   WithExternalId,
   WithId,
@@ -21,7 +22,6 @@ final case class SequenceColumn(
     // externalId must be optional until all data created using v0.6
     // of the API has been migrated and this field has been marked as
     // required in the official API docs.
-    // See also our custom transformer in common/package.scala
     externalId: Option[String] = None,
     description: Option[String] = None,
     // TODO: Turn this into an enum.
@@ -31,7 +31,23 @@ final case class SequenceColumn(
     metadata: Option[Map[String, String]] = None,
     createdTime: Instant = Instant.ofEpochMilli(0),
     lastUpdatedTime: Instant = Instant.ofEpochMilli(0)
-)
+) extends ToCreate[SequenceColumnCreate] {
+  override def toCreate: SequenceColumnCreate =
+    SequenceColumnCreate(
+      name,
+      // externalId is optional when reading, despite being required when
+      // writing. This is due to it being optional in v0.6, and data from
+      // there has not yet been migrated.
+      // When it has, and externalId has been marked as required in the
+      // official API docs, we should be able to remove this.
+      externalId.getOrElse(
+        throw new RuntimeException("Can't create sequence column without externalId")
+      ),
+      description,
+      valueType,
+      metadata
+    )
+}
 
 final case class SequenceColumnCreate(
     name: Option[String] = None,
@@ -58,6 +74,29 @@ final case class Sequence(
 ) extends WithId[Long]
     with WithExternalId
     with WithCreatedTime
+    with ToCreate[SequenceCreate]
+    with ToUpdate[SequenceUpdate] {
+  override def toCreate: SequenceCreate =
+    SequenceCreate(
+      name,
+      description,
+      assetId,
+      externalId,
+      metadata,
+      columns.map(_.toCreate),
+      dataSetId
+    )
+
+  override def toUpdate: SequenceUpdate =
+    SequenceUpdate(
+      Setter.fromOption(name),
+      Setter.fromOption(description),
+      Setter.fromOption(assetId),
+      Setter.fromOption(externalId),
+      NonNullableSetter.fromOption(metadata),
+      Setter.fromOption(dataSetId)
+    )
+}
 
 final case class SequenceCreate(
     name: Option[String] = None,

--- a/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/threeD.scala
@@ -4,8 +4,7 @@
 package com.cognite.sdk.scala.v1
 
 import java.time.Instant
-
-import com.cognite.sdk.scala.common.{NonNullableSetter, WithId}
+import com.cognite.sdk.scala.common.{NonNullableSetter, ToCreate, ToUpdate, WithId}
 
 final case class ThreeDModel(
     name: String,
@@ -13,6 +12,17 @@ final case class ThreeDModel(
     createdTime: Instant = Instant.ofEpochMilli(0),
     metadata: Option[Map[String, String]] = None
 ) extends WithId[Long]
+    with ToCreate[ThreeDModelCreate]
+    with ToUpdate[ThreeDModelUpdate] {
+  override def toCreate: ThreeDModelCreate = ThreeDModelCreate(name, metadata)
+
+  override def toUpdate: ThreeDModelUpdate =
+    ThreeDModelUpdate(
+      id,
+      Some(NonNullableSetter.fromAny(name)),
+      NonNullableSetter.fromOption(metadata)
+    )
+}
 
 final case class ThreeDModelCreate(
     name: String,
@@ -52,6 +62,26 @@ final case class ThreeDRevision(
     assetMappingCount: Long = 0,
     createdTime: Instant = Instant.ofEpochMilli(0)
 ) extends WithId[Long]
+    with ToCreate[ThreeDRevisionCreate]
+    with ToUpdate[ThreeDRevisionUpdate] {
+  override def toCreate: ThreeDRevisionCreate =
+    ThreeDRevisionCreate(
+      published,
+      rotation,
+      metadata,
+      camera,
+      fileId
+    )
+
+  override def toUpdate: ThreeDRevisionUpdate =
+    ThreeDRevisionUpdate(
+      id,
+      Some(NonNullableSetter.fromAny(published)),
+      NonNullableSetter.fromOption(rotation),
+      NonNullableSetter.fromOption(camera),
+      NonNullableSetter.fromOption(metadata)
+    )
+}
 
 final case class ThreeDRevisionCreate(
     published: Boolean,

--- a/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
@@ -23,11 +23,38 @@ final case class TimeSeries(
 ) extends WithId[Long]
     with WithExternalId
     with WithCreatedTime
+    with ToCreate[TimeSeriesCreate]
+    with ToUpdate[TimeSeriesUpdate] {
+  override def toCreate: TimeSeriesCreate =
+    TimeSeriesCreate(
+      externalId,
+      name,
+      isString,
+      metadata,
+      unit,
+      assetId,
+      isStep,
+      description,
+      securityCategories,
+      dataSetId
+    )
+
+  override def toUpdate: TimeSeriesUpdate =
+    TimeSeriesUpdate(
+      Setter.fromOption(name),
+      Setter.fromOption(externalId),
+      NonNullableSetter.fromOption(metadata),
+      Setter.fromOption(unit),
+      Setter.fromOption(assetId),
+      Setter.fromOption(description),
+      NonNullableSetter.fromOption(securityCategories),
+      Setter.fromOption(dataSetId)
+    )
+}
 
 final case class TimeSeriesCreate(
     externalId: Option[String] = None,
     name: Option[String] = None,
-    legacyName: Option[String] = None,
     isString: Boolean = false,
     metadata: Option[Map[String, String]] = None,
     unit: Option[String] = None,

--- a/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/DataPointsResourceBehaviors.scala
@@ -12,6 +12,7 @@ import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 trait DataPointsResourceBehaviors extends Matchers with OptionValues with RetryWhile { this: AnyFlatSpec =>
   private val startTime = System.currentTimeMillis()
   private val start = Instant.ofEpochMilli(startTime)
@@ -27,7 +28,7 @@ trait DataPointsResourceBehaviors extends Matchers with OptionValues with RetryW
     it should "be possible to insert and delete numerical data points" in withTimeSeries {
       timeSeries =>
         val timeSeriesId = timeSeries.id
-        val timeSeriesExternalId = timeSeries.externalId.get
+        val timeSeriesExternalId = timeSeries.externalId.value
         dataPoints.insertById(timeSeriesId, testDataPoints)
 
         retryWithExpectedResult[DataPointsByIdResponse](
@@ -44,7 +45,7 @@ trait DataPointsResourceBehaviors extends Matchers with OptionValues with RetryW
           dataPoints.getLatestDataPointById(timeSeriesId),
           dp => {
             dp.isDefined shouldBe true
-            testDataPoints.toList should contain(dp.get)
+            testDataPoints.toList should contain(dp.value)
           }
         )
 
@@ -69,7 +70,7 @@ trait DataPointsResourceBehaviors extends Matchers with OptionValues with RetryW
           dataPoints.getLatestDataPointByExternalId(timeSeriesExternalId),
           { l2 =>
             l2.isDefined shouldBe true
-            testDataPoints.toList should contain(l2.get)
+            testDataPoints.toList should contain(l2.value)
           }
         )
 

--- a/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
@@ -4,20 +4,23 @@
 package com.cognite.sdk.scala.common
 
 import com.cognite.sdk.scala.v1.Client
+import io.circe.{Codec, Decoder, Encoder}
 import sttp.client3._
 import sttp.client3.testing.SttpBackendStub
 import io.circe.parser.decode
-import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+import io.circe.generic.semiauto.{deriveCodec, deriveDecoder, deriveEncoder}
+import org.scalatest.OptionValues
 import sttp.model.StatusCode
 
-case class DummyFilter()
+final case class DummyFilter()
+object DummyFilter {
+  implicit val dummyFilterCodec: Codec[DummyFilter] = deriveCodec[DummyFilter]
+}
 
-class FilterTest extends SdkTestSpec {
-  implicit val dummyFilterEncoder = deriveEncoder[DummyFilter]
-  implicit val dummyFilterRequestEncoder = deriveEncoder[FilterRequest[DummyFilter]]
-  implicit val dummyFilterDecoder = deriveDecoder[DummyFilter]
-  implicit val dummyFilterRequestDecoder = deriveDecoder[FilterRequest[DummyFilter]]
-  implicit val dummyItemsWithCursorDecoder = deriveDecoder[ItemsWithCursor[Int]]
+class FilterTest extends SdkTestSpec with OptionValues {
+  private implicit val dummyFilterRequestEncoder: Encoder[FilterRequest[DummyFilter]] = deriveEncoder[FilterRequest[DummyFilter]]
+  private implicit val dummyFilterRequestDecoder: Decoder[FilterRequest[DummyFilter]] = deriveDecoder[FilterRequest[DummyFilter]]
+  private implicit val dummyItemsWithCursorDecoder: Decoder[ItemsWithCursor[Int]] = deriveDecoder[ItemsWithCursor[Int]]
 
   it should "set final limit to batchSize when less than limit" in filterWithCursor(10, Some(100)) { finalLimit =>
     finalLimit should be(10)
@@ -31,6 +34,7 @@ class FilterTest extends SdkTestSpec {
     finalLimit should be(100)
   }
 
+  @SuppressWarnings(Array("org.wartremover.warts.Null", "org.wartremover.warts.Var"))
   def filterWithCursor(batchSize: Int, limit: Option[Int])(test: Int => Any): Any = {
     var hijackedRequest: FilterRequest[DummyFilter] = null // scalastyle:ignore
     val requestHijacker = SttpBackendStub.synchronous.whenAnyRequest.thenRespondF(req => {
@@ -46,7 +50,7 @@ class FilterTest extends SdkTestSpec {
       auth)(requestHijacker)
     val dummyRequestSession = dummyClient.requestSession
 
-    Filter.filterWithCursor(
+    val _ = Filter.filterWithCursor(
       dummyRequestSession,
       uri"https://test.com",
       DummyFilter(),
@@ -56,6 +60,6 @@ class FilterTest extends SdkTestSpec {
       batchSize,
       None
     )
-    test(hijackedRequest.limit.get)
+    test(hijackedRequest.limit.value)
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/GzipSttpBackendTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/GzipSttpBackendTest.scala
@@ -18,7 +18,8 @@ import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.server.handler.gzip.GzipHandler
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.scalatest.flatspec.AnyFlatSpec
-import org.scalatest.{BeforeAndAfter, EitherValues, OptionValues}
+import org.scalatest.{BeforeAndAfter, OptionValues}
+import org.scalatest.EitherValues.convertEitherToValuable
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.io.Source
@@ -29,28 +30,28 @@ class EchoServlet extends HttpServlet {
     Option(req.getHeader("X-Content-Length"))
       .orElse(Option(req.getHeader("Content-Length")))
       .foreach(resp.addHeader(GzipSttpBackendTest.originalLength, _))
-    IOUtils.copy(req.getInputStream, resp.getOutputStream)
+    val _ = IOUtils.copy(req.getInputStream, resp.getOutputStream)
     ()
   }
 }
 
-class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValues with BeforeAndAfter {
+@SuppressWarnings(Array("org.wartremover.warts.GlobalExecutionContext", "org.wartremover.warts.NonUnitStatements"))
+class GzipSttpBackendTest extends AnyFlatSpec with OptionValues with BeforeAndAfter {
   implicit val cs: ContextShift[IO] = IO.contextShift(global)
   implicit val timer: Timer[IO] = IO.timer(global)
 
   val port: Int = 50000 + (java.lang.Math.random() * 1000).toInt
 
-  var server: Server = _
-  val gzipHandler = new GzipHandler()
+  val server: Server = new Server(port)
+  private val gzipHandler = new GzipHandler()
   gzipHandler.addIncludedMethods("POST")
   gzipHandler.setInflateBufferSize(8096)
-  val servletHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
+  private val servletHandler = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
   servletHandler.setGzipHandler(gzipHandler)
   servletHandler.setInitParameter("gzip", "true")
   servletHandler.addServlet(classOf[EchoServlet], "/")
 
   before {
-    server = new Server(port)
     server.setHandler(servletHandler)
     server.start()
   }
@@ -74,7 +75,7 @@ class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValue
     val r = request.send(sttpBackend).unsafeRunSync()
     // Very small strings will be larger when compressed.
     assert(
-      r.header(GzipSttpBackendTest.originalLength).value.toInt == smallTestString.getBytes().length
+      r.header(GzipSttpBackendTest.originalLength).value.toInt === smallTestString.getBytes(StandardCharsets.UTF_8).length
     )
     assert(r.body.value contains smallTestString)
   }
@@ -85,40 +86,40 @@ class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValue
       .post(uri"http://localhost:$port/string")
     val r = request.send(sttpBackend).unsafeRunSync()
     assert(
-      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes().length
+      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes(StandardCharsets.UTF_8).length
     )
     assert(r.body.value contains longTestString)
   }
 
   it should "compress byte array bodies" in {
     val request = basicRequest
-      .body(longTestString.getBytes)
+      .body(longTestString.getBytes(StandardCharsets.UTF_8))
       .post(uri"http://localhost:$port/bytearray")
     val r = request.send(sttpBackend).unsafeRunSync()
     assert(
-      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes().length
+      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes(StandardCharsets.UTF_8).length
     )
     assert(r.body.value contains longTestString)
   }
 
   it should "compress byte buffer bodies" in {
     val request = basicRequest
-      .body(ByteBuffer.wrap(longTestString.getBytes))
+      .body(ByteBuffer.wrap(longTestString.getBytes(StandardCharsets.UTF_8)))
       .post(uri"http://localhost:$port/bytebuffer")
     val r = request.send(sttpBackend).unsafeRunSync()
     assert(
-      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes().length
+      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes(StandardCharsets.UTF_8).length
     )
     assert(r.body.value contains longTestString)
   }
 
   it should "compress input stream bodies" in {
     val request = basicRequest
-      .body(new ByteArrayInputStream(longTestString.getBytes))
+      .body(new ByteArrayInputStream(longTestString.getBytes(StandardCharsets.UTF_8)))
       .post(uri"http://localhost:$port/inputstream")
     val r = request.send(sttpBackend).unsafeRunSync()
     assert(
-      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes().length
+      r.header(GzipSttpBackendTest.originalLength).value.toInt < longTestString.getBytes(StandardCharsets.UTF_8).length
     )
     assert(r.body.value contains longTestString)
   }
@@ -127,7 +128,7 @@ class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValue
     val request = basicRequest
       .multipartBody(
         multipart("string", "abc"),
-        multipart("inputstream", new ByteArrayInputStream("defg".getBytes))
+        multipart("inputstream", new ByteArrayInputStream("defg".getBytes(StandardCharsets.UTF_8)))
       )
       .post(uri"http://localhost:$port/multipart")
     val r = request.send(sttpBackend).unsafeRunSync()
@@ -143,7 +144,7 @@ class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValue
     val r = request.send(sttpBackend).unsafeRunSync()
     val source = Source.fromFile(
       Paths.get("./src/test/scala/com/cognite/sdk/scala/v1/uploadTest.txt").toFile
-    )
+    )(scala.io.Codec.UTF8)
     try {
       assert(r.body.value contains source.mkString)
     } finally {
@@ -158,7 +159,7 @@ class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValue
       .header("Content-encoding", "gzip")
       .post(uri"http://localhost:$port/donotcompress")
     val r = request.send(sttpBackend).unsafeRunSync()
-    assert(r.header(GzipSttpBackendTest.originalLength).value.toInt == compressedBody.length)
+    assert(r.header(GzipSttpBackendTest.originalLength).value.toInt === compressedBody.length)
     assert(r.body.value contains longTestString)
 
     val request2 = basicRequest
@@ -171,8 +172,8 @@ class GzipSttpBackendTest extends AnyFlatSpec with EitherValues with OptionValue
     val gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(r2.body.value))
     try {
       val uncompressedBody = new String(IOUtils.toByteArray(gzipInputStream), StandardCharsets.UTF_8)
-      assert(r2.header(GzipSttpBackendTest.originalLength).value.toInt == compressedBody.length)
-      assert(uncompressedBody == longTestString)
+      assert(r2.header(GzipSttpBackendTest.originalLength).value.toInt === compressedBody.length)
+      assert(uncompressedBody === longTestString)
     } finally {
       gzipInputStream.close()
     }

--- a/src/test/scala/com/cognite/sdk/scala/common/LoginTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/LoginTest.scala
@@ -4,6 +4,7 @@
 package com.cognite.sdk.scala.common
 
 import cats.Id
+import cats.catsInstancesForId
 import com.cognite.sdk.scala.v1.RequestSession
 import sttp.client3._
 
@@ -17,7 +18,7 @@ class LoginTest extends SdkTestSpec {
     val login =
       new Login(RequestSession[Id]("scala-sdk-test", uri"https://api.cognitedata.com", backend, AuthProvider[Id](auth)))
     val status = login.status()
-    status.loggedIn should be(true)
+    assert(status.loggedIn)
     status.project should not be empty
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
@@ -4,13 +4,16 @@
 package com.cognite.sdk.scala.common
 
 import com.cognite.sdk.scala.v1.Client
+import io.circe.Decoder
 import sttp.client3._
 import sttp.client3.testing.SttpBackendStub
 import io.circe.generic.semiauto.deriveDecoder
+import org.scalatest.OptionValues
 import sttp.model.Uri.QuerySegment
 
-class ReadTest extends SdkTestSpec {
-  implicit val dummyItemsWithCursorDecoder = deriveDecoder[ItemsWithCursor[Int]]
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Var"))
+class ReadTest extends SdkTestSpec with OptionValues {
+  private implicit val dummyItemsWithCursorDecoder: Decoder[ItemsWithCursor[Int]] = deriveDecoder[ItemsWithCursor[Int]]
   it should "set final limit to batchSize when less than limit" in readWithCursor(10, Some(100)) { finalLimit =>
     finalLimit should be(10)
   }
@@ -26,9 +29,9 @@ class ReadTest extends SdkTestSpec {
   def readWithCursor(batchSize: Int, limit: Option[Int])(test: Int => Any): Any = {
     var totalLimit = 0
     val requestHijacker = SttpBackendStub.synchronous.whenAnyRequest.thenRespondF(req => {
-      totalLimit = req.uri.querySegments.collectFirst {
+      totalLimit += req.uri.querySegments.collectFirst {
         case q @ QuerySegment.KeyValue("limit", _, _, _) => q.v.toInt
-      }.get
+      }.value
       Response.ok(0)
     })
     lazy val dummyClient = Client("foo",

--- a/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
@@ -5,12 +5,15 @@ package com.cognite.sdk.scala.common
 
 import scala.concurrent.duration.FiniteDuration
 import scala.concurrent.duration._
-import scala.util.Random
+import scala.util.{Failure, Random, Success, Try}
 import org.scalatest.Assertion
 import org.scalatest.exceptions.TestFailedException
 
+import scala.annotation.tailrec
+
 trait RetryWhile {
-  def retryWithExpectedResult[A](
+  @tailrec
+  final def retryWithExpectedResult[A](
       action: => A,
       assertion: A => Assertion,
       retriesRemaining: Int = Constants.DefaultMaxRetries,
@@ -20,15 +23,16 @@ trait RetryWhile {
     val randomDelayScale =
       (Constants.DefaultMaxBackoffDelay / 2).min(Constants.DefaultInitialRetryDelay * 2).toMillis
     val nextDelay = Random.nextInt(randomDelayScale.toInt).millis + exponentialDelay
-    try {
+    Try {
       val result = action
-      assertion(result)
+      val _ = assertion(result)
       result
-    } catch {
-      case _: TestFailedException if (retriesRemaining > 0) => {
+    } match {
+      case Failure(_: TestFailedException) if retriesRemaining > 0 =>
         Thread.sleep(initialDelay.toMillis)
         retryWithExpectedResult[A](action, assertion, retriesRemaining - 1, nextDelay)
-      }
+      case Failure(exception) => throw exception
+      case Success(value) => value
     }
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/SdkTestSpec.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/SdkTestSpec.scala
@@ -5,6 +5,7 @@ package com.cognite.sdk.scala.common
 
 import java.util.UUID
 import cats.Id
+import cats.catsInstancesForId
 import com.cognite.sdk.scala.v1._
 import com.cognite.sdk.scala.v1.resources.DataSets
 import sttp.client3.{Request, Response, SttpBackend}
@@ -20,20 +21,20 @@ class LoggingSttpBackend[F[_], +P](delegate: SttpBackend[F, P]) extends SttpBack
     responseMonad.map(try {
       responseMonad.handleError(delegate.send(request)) {
         case e: Exception =>
-          println(s"Exception when sending request: $request, ${e.toString}") // scalastyle:ignore
+          println(s"Exception when sending request: ${request.toString}, ${e.toString}") // scalastyle:ignore
           responseMonad.error(e)
       }
     } catch {
       case NonFatal(e) =>
-        println(s"Exception when sending request: $request, ${e.toString}") // scalastyle:ignore
+        println(s"Exception when sending request: ${request.toString}, ${e.toString}") // scalastyle:ignore
         throw e
     }) { response =>
       println(s"request ${request.body.toString}") // scalastyle:ignore
       println(s"response ${response.toString}") // scalastyle:ignore
       if (response.isSuccess) {
-        println(s"For request: $request got response: $response") // scalastyle:ignore
+        println(s"For request: ${request.toString} got response: ${response.toString}") // scalastyle:ignore
       } else {
-        println(s"For request: $request got response: $response") // scalastyle:ignore
+        println(s"For request: ${request.toString} got response: ${response.toString}") // scalastyle:ignore
       }
       response
     }

--- a/src/test/scala/com/cognite/sdk/scala/common/StringDataPointsResourceBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/StringDataPointsResourceBehaviors.scala
@@ -13,6 +13,7 @@ import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 trait StringDataPointsResourceBehaviors extends Matchers with OptionValues with RetryWhile { this: AnyFlatSpec =>
   private val startTime = System.currentTimeMillis()
   private val start = Instant.ofEpochMilli(startTime)
@@ -28,7 +29,7 @@ trait StringDataPointsResourceBehaviors extends Matchers with OptionValues with 
     it should "be possible to insert and delete string data points" in withStringTimeSeries {
       stringTimeSeries =>
       val stringTimeSeriesId = stringTimeSeries.id
-        val stringTimeSeriesExternalId = stringTimeSeries.externalId.get
+        val stringTimeSeriesExternalId = stringTimeSeries.externalId.value
         dataPoints.insertStringsById(stringTimeSeriesId, testStringDataPoints)
 
         retryWithExpectedResult[StringDataPointsByIdResponse](
@@ -40,7 +41,7 @@ trait StringDataPointsResourceBehaviors extends Matchers with OptionValues with 
           dataPoints.getLatestStringDataPointById(stringTimeSeriesId),
           dp => {
             dp.isDefined shouldBe true
-            testStringDataPoints.toList should contain(dp.get)
+            testStringDataPoints.toList should contain(dp.value)
           }
         )
 
@@ -57,7 +58,7 @@ trait StringDataPointsResourceBehaviors extends Matchers with OptionValues with 
 
         val resultId2: Seq[_] = dataPoints.queryStringsByIds(Seq(stringTimeSeriesId), start, end.plusMillis(1))
         resultId2.length shouldBe 1
-        resultId2.head shouldBe resultId
+        resultId2.headOption.value shouldBe resultId
 
         dataPoints.insertStringsByExternalId(stringTimeSeriesExternalId, testStringDataPoints)
         val resultExternalId: StringDataPointsByExternalIdResponse = retryWithExpectedResult[StringDataPointsByExternalIdResponse](
@@ -72,13 +73,13 @@ trait StringDataPointsResourceBehaviors extends Matchers with OptionValues with 
 
         val resultExternalId2: Seq[StringDataPointsByExternalIdResponse] = dataPoints.queryStringsByExternalIds(Seq(stringTimeSeriesExternalId), start, end.plusMillis(1))
         resultExternalId2.length shouldBe 1
-        resultExternalId2.head shouldBe resultExternalId
+        resultExternalId2.headOption.value shouldBe resultExternalId
 
         retryWithExpectedResult[Option[StringDataPoint]](
           dataPoints.getLatestStringDataPointByExternalId(stringTimeSeriesExternalId),
           l2 => {
             l2.isDefined shouldBe true
-            testStringDataPoints.toList should contain(l2.get)
+            testStringDataPoints.toList should contain(l2.value)
           }
         )
 
@@ -90,7 +91,7 @@ trait StringDataPointsResourceBehaviors extends Matchers with OptionValues with 
     }
 
     it should "support support query by externalId when ignoreUnknownIds=true" in {
-      val doesNotExist = "does-not-exist-" + UUID.randomUUID
+      val doesNotExist = s"does-not-exist-${UUID.randomUUID.toString}"
       dataPoints.getLatestStringDataPointByExternalIds(Seq(doesNotExist), ignoreUnknownIds = true) shouldBe empty
       dataPoints.getLatestDataPointsByExternalIds(Seq(doesNotExist), ignoreUnknownIds = true) shouldBe empty
       dataPoints.queryByExternalIds(Seq(doesNotExist), Instant.EPOCH, Instant.now, ignoreUnknownIds = true) shouldBe empty

--- a/src/test/scala/com/cognite/sdk/scala/common/WritableBehaviors.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/WritableBehaviors.scala
@@ -4,21 +4,21 @@
 package com.cognite.sdk.scala.common
 
 import cats.Id
-import io.scalaland.chimney.Transformer
 import org.scalatest.OptionValues
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =>
   // scalastyle:off
-  def writable[R <: WithId[PrimitiveId], W, PrimitiveId](
+  def writable[R <: ToCreate[W] with WithId[PrimitiveId], W, PrimitiveId](
       writable: Create[R, W, Id] with CreateOne[R, W, Id],
       maybeDeletable: Option[DeleteByIds[Id, PrimitiveId]],
       readExamples: Seq[R],
       createExamples: Seq[W],
       idsThatDoNotExist: Seq[PrimitiveId],
       supportsMissingAndThrown: Boolean
-  )(implicit t: Transformer[R, W]): Unit = {
+  ): Unit = {
     it should "be an error to delete using ids that does not exist" in {
       maybeDeletable.map { deletable =>
         val thrown = the[CdpApiException] thrownBy deletable.deleteByIds(idsThatDoNotExist)
@@ -30,7 +30,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
           missingIds should contain theSameElementsAs idsThatDoNotExist
         }
 
-        val sameIdsThatDoNotExist = Seq(idsThatDoNotExist.head, idsThatDoNotExist.head)
+        val sameIdsThatDoNotExist = Seq.fill(2)(idsThatDoNotExist(0))
         val sameIdsThrown = the[CdpApiException] thrownBy deletable.deleteByIds(
           sameIdsThatDoNotExist
         )
@@ -63,7 +63,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       // create a single item
       val createdItem = writable.createFromRead(readExamples.take(1))
       createdItem should have size 1
-      createdItem.head.id should not be 0
+      createdItem.headOption.value.id should not be 0
 
       maybeDeletable.map(_.deleteByIds(createdItem.map(_.id)))
 
@@ -80,7 +80,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       // create a single item
       val createdItem = writable.create(createExamples.take(1))
       createdItem should have size 1
-      createdItem.head.id should not be 0
+      createdItem.headOption.value.id should not be 0
 
       maybeDeletable.map(_.deleteByIds(createdItem.map(_.id)))
 
@@ -96,7 +96,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
     //       id in the same api call for V1
   }
 
-  def writableWithExternalId[R <: WithExternalIdGeneric[Option], W <: WithExternalIdGeneric[
+  def writableWithExternalId[R <: ToCreate[W] with WithExternalIdGeneric[Option], W <: WithExternalIdGeneric[
     Option
   ]](
       writable: Create[R, W, Id],
@@ -105,7 +105,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       createExamples: Seq[W],
       externalIdsThatDoNotExist: Seq[String],
       supportsMissingAndThrown: Boolean
-  )(implicit t: Transformer[R, W]) =
+  ): Unit =
     writableWithExternalIdGeneric[Option, R, W](
       writable,
       maybeDeletable,
@@ -115,7 +115,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       supportsMissingAndThrown
     )
 
-  def writableWithRequiredExternalId[R <: WithExternalIdGeneric[Id], W <: WithExternalIdGeneric[
+  def writableWithRequiredExternalId[R <: ToCreate[W] with WithExternalIdGeneric[Id], W <: WithExternalIdGeneric[
     Id
   ]](
       writable: Create[R, W, Id],
@@ -125,7 +125,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       externalIdsThatDoNotExist: Seq[String],
       supportsMissingAndThrown: Boolean,
       trySameIdsThatDoNotExist: Boolean = true
-  )(implicit t: Transformer[R, W]) =
+  ): Unit =
     writableWithExternalIdGeneric[Id, R, W](
       writable,
       maybeDeletable,
@@ -136,7 +136,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       trySameIdsThatDoNotExist
   )
 
-  def writableWithExternalIdGeneric[A[_], R <: WithExternalIdGeneric[A], W <: WithExternalIdGeneric[
+  def writableWithExternalIdGeneric[A[_], R <: ToCreate[W] with WithExternalIdGeneric[A], W <: WithExternalIdGeneric[
     A
   ]](
       writable: Create[R, W, Id],
@@ -146,7 +146,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       externalIdsThatDoNotExist: Seq[String],
       supportsMissingAndThrown: Boolean,
       trySameIdsThatDoNotExist: Boolean = true
-  )(implicit t: Transformer[R, W]): Unit = {
+  ): Unit = {
     it should "be an error to delete using external ids that does not exist" in {
       maybeDeletable.map { deletable =>
         val thrown = the[CdpApiException] thrownBy deletable.deleteByExternalIds(
@@ -170,8 +170,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
           //        [items is not a distinct set; duplicates: [{\"externalId\":\"AT_Matzen a469\"}]]"
           //    }
           //}
-          val sameIdsThatDoNotExist =
-            Seq(externalIdsThatDoNotExist.head, externalIdsThatDoNotExist.head)
+          val sameIdsThatDoNotExist = Seq.fill(2)(externalIdsThatDoNotExist(0))
           val sameIdsThrown = the[CdpApiException] thrownBy deletable.deleteByExternalIds(
             sameIdsThatDoNotExist
           )
@@ -196,7 +195,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
     it should "create and delete items using the read class and external ids" in {
       val createdItems = writable.createFromRead(readExamples)
       createdItems should have size readExamples.size.toLong
-      val createdExternalIds = createdItems.flatMap(_.getExternalId())
+      val createdExternalIds = createdItems.map(_.getExternalId().value)
       createdExternalIds should have size readExamples.size.toLong
       maybeDeletable.map(_.deleteByExternalIds(createdExternalIds))
     }
@@ -205,7 +204,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       // create multiple items
       val createdItems = writable.create(createExamples)
       createdItems should have size createExamples.size.toLong
-      val createdIds = createdItems.flatMap(_.getExternalId())
+      val createdIds = createdItems.map(_.getExternalId().value)
       createdIds should have size createExamples.size.toLong
       maybeDeletable.map(_.deleteByExternalIds(createdIds))
     }
@@ -213,7 +212,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
     //       id in the same api call for V1
   }
 
-  def updatable[R <: WithId[Long], W, U](
+  def updatable[R <: ToCreate[W] with ToUpdate[U] with WithId[Long], W, U](
       updatable: Create[R, W, Id] with UpdateById[R, U, Id] with RetrieveByIds[R, Id],
       maybeDeletable: Option[DeleteByIds[Id, Long]],
       readExamples: Seq[R],
@@ -221,7 +220,7 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       updateId: (Long, R) => R,
       compareItems: (R, R) => Boolean,
       compareUpdated: (Seq[R], Seq[R]) => Unit
-  )(implicit t: Transformer[R, W], t2: Transformer[R, U]): Unit =
+  ): Unit =
     it should "allow updates using the read class" in {
       // create items
       val createdIds = updatable.createFromRead(readExamples).map(_.id)
@@ -249,28 +248,28 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       maybeDeletable.map(_.deleteByIds(createdIds))
     }
 
-  def updatableByExternalId[R <: WithExternalId, W, U](
+  def updatableByExternalId[R <: ToCreate[W] with WithExternalId, W, U](
       resource: Create[R, W, Id] with UpdateByExternalId[R, U, Id] with RetrieveByIds[R, Id],
       maybeDeletable: Option[DeleteByExternalIds[Id]],
       itemsToCreate: Seq[R],
       updatesToMake: Map[String, U],
       expectedBehaviors: (Seq[R], Seq[R]) => Unit
-  )(implicit t: Transformer[R, W]): Unit =
+  ): Unit =
     it should "allow updating by externalId" in {
       val createdItems = resource.createFromRead(itemsToCreate)
       val updatedItems = resource.updateByExternalId(updatesToMake)
       expectedBehaviors(createdItems, updatedItems)
 
-      maybeDeletable.map(_.deleteByExternalIds(updatedItems.map(_.externalId.get)))
+      maybeDeletable.map(_.deleteByExternalIds(updatedItems.map(_.externalId.value)))
     }
 
-  def updatableById[R <: WithId[Long], W, U](
+  def updatableById[R <: ToCreate[W] with ToUpdate[U] with WithId[Long], W, U](
       resource: Create[R, W, Id] with UpdateById[R, U, Id] with RetrieveByIds[R, Id],
       maybeDeletable: Option[DeleteByIds[Id, Long]],
       itemsToCreate: Seq[R],
       updatesToMake: Seq[U],
       expectedBehaviors: (Seq[R], Seq[R]) => Unit
-  )(implicit t: Transformer[R, W]): Unit =
+  ): Unit =
     it should "allow updating by Id" in {
       val createdItems = resource.createFromRead(itemsToCreate)
       val updateMap = createdItems.indices.map(i => (createdItems(i).id, updatesToMake(i))).toMap
@@ -280,24 +279,24 @@ trait WritableBehaviors extends Matchers with OptionValues { this: AnyFlatSpec =
       maybeDeletable.map(_.deleteByIds(updatedItems.map(_.id)))
     }
 
-  def deletableWithIgnoreUnknownIds[R <: WithId[Long], W, PrimitiveId](
+  def deletableWithIgnoreUnknownIds[R <: ToCreate[W] with WithId[Long], W, PrimitiveId](
       writable: Create[R, W, Id]
         with DeleteByIdsWithIgnoreUnknownIds[Id, Long]
         with RetrieveByIds[R, Id],
       readExamples: Seq[R],
       idsThatDoNotExist: Seq[Long]
-  )(implicit t: Transformer[R, W]): Unit =
+  ): Unit =
     it should "support ignoring unknown ids on delete" in {
       val createdItems: Id[Seq[R]] = writable.createFromRead(readExamples)
       val createdIds = createdItems.map(_.id)
       val createdAndSomeNonExistingIds = createdIds ++ idsThatDoNotExist
       writable.deleteByIds(createdAndSomeNonExistingIds, ignoreUnknownIds = true)
       val retrieveDeletedException = intercept[CdpApiException](writable.retrieveByIds(createdIds))
-      assert(retrieveDeletedException.code == 400)
+      assert(retrieveDeletedException.code === 400)
       val doNotIgnoreException = intercept[CdpApiException](
         writable.deleteByIds(idsThatDoNotExist)
       )
-      assert(doNotIgnoreException.code == 400)
+      assert(doNotIgnoreException.code === 400)
     }
 
 //    it should "create and delete items using the create class" in {

--- a/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/AssetsTest.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 import com.cognite.sdk.scala.common._
 import fs2.Stream
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with RetryWhile {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
@@ -90,7 +91,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
       r => r should have size 3
     )
 
-    client.assets.deleteByIds(Seq(createdItems.head.id), true, true)
+    client.assets.deleteByIds(Seq(createdItems(0).id), true, true)
 
     retryWithExpectedResult[Seq[Asset]](
       client.assets.filter(AssetsFilter(externalIdPrefix = Some(s"$key-recursive"))).compile.toList,
@@ -113,15 +114,15 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
     assetUpdates,
     (id: Long, item: Asset) => item.copy(id = id),
     (a: Asset, b: Asset) => {
-      a.copy(lastUpdatedTime = Instant.ofEpochMilli(0)) == b.copy(lastUpdatedTime = Instant.ofEpochMilli(0))
+      a.copy(lastUpdatedTime = Instant.ofEpochMilli(0)) === b.copy(lastUpdatedTime = Instant.ofEpochMilli(0))
     },
     (readAssets: Seq[Asset], updatedAssets: Seq[Asset]) => {
       assert(assetsToCreate.size == assetUpdates.size)
       assert(readAssets.size == assetsToCreate.size)
       assert(updatedAssets.size == assetUpdates.size)
-      assert(updatedAssets.zip(readAssets).forall { case (updated, read) =>  updated.name == s"${read.name}-1" })
-      assert(updatedAssets.head.description.isEmpty)
-      assert(updatedAssets(1).description == readAssets(1).description)
+      assert(updatedAssets.zip(readAssets).forall { case (updated, read) =>  updated.name === s"${read.name}-1" })
+      assert(updatedAssets(0).description.isEmpty)
+      assert(updatedAssets(1).description === readAssets(1).description)
       val dataSets = updatedAssets.map(_.dataSetId)
       assert(List(Some(testDataSet.id), Some(testDataSet.id)) === dataSets)
       ()
@@ -140,7 +141,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
       assert(assetsToCreate.size == assetUpdates.size)
       assert(readAssets.size == assetsToCreate.size)
       assert(updatedAssets.size == assetUpdates.size)
-      assert(updatedAssets.zip(readAssets).forall { case (updated, read) => updated.name == s"${read.name}-1" })
+      assert(updatedAssets.zip(readAssets).forall { case (updated, read) => updated.name === s"${read.name}-1" })
       val dataSets = updatedAssets.map(_.dataSetId)
       assert(List(None, None) === dataSets)
       ()
@@ -159,8 +160,8 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
       assert(assetsToCreate.size == assetUpdates.size)
       assert(readAssets.size == assetsToCreate.size)
       assert(updatedAssets.size == assetUpdates.size)
-      assert(updatedAssets.zip(readAssets).forall { case (updated, read) =>  updated.name == s"${read.name}-1" })
-      assert(updatedAssets.zip(readAssets).forall { case (updated, read) => updated.externalId == read.externalId })
+      assert(updatedAssets.zip(readAssets).forall { case (updated, read) =>  updated.name === s"${read.name}-1" })
+      assert(updatedAssets.zip(readAssets).forall { case (updated, read) => updated.externalId === read.externalId })
       ()
     }
   )
@@ -240,7 +241,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
         ), Some(5), Some(Seq("childCount")))
         .compile.toList,
       a => {
-        val bool = a.map(_.aggregates.get("childCount")).exists(_ > 0)
+        val bool = a.map(_.aggregates.value.get("childCount").value).exists(_ > 0)
         bool shouldBe true
       }
     )
@@ -299,7 +300,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
           filter = Some(AssetsFilter(parentExternalIds = Some(Seq("test-root"))))
         )
       )
-    assert(testAssets.map(_.parentExternalId) == Seq(Some("test-root"), Some("test-root")))
+    assert(testAssets.map(_.parentExternalId) === Seq(Some("test-root"), Some("test-root")))
   }
 
   it should "not be an error to request more assets than the API limit" in {
@@ -321,7 +322,7 @@ class AssetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
         a => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
-      created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)
+      created.filter(_.dataSetId.isDefined).map(_.id) should contain theSameElementsAs foundItems.map(_.id)
     } finally {
       client.assets.deleteByIds(created.map(_.id))
     }

--- a/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
@@ -8,6 +8,7 @@ import java.util.UUID
 
 import com.cognite.sdk.scala.common.{CdpApiException, DataPointsResourceBehaviors, SdkTestSpec}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements"))
 class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
   override def withTimeSeries(testCode: TimeSeries => Any): Unit = {
     val name = Some(s"data-points-test-${UUID.randomUUID().toString}")
@@ -91,7 +92,7 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
     extAverages.map(_.timestamp).tail should contain theSameElementsInOrderAs extStepInterpolation.map(_.timestamp)
     extAverages.map(_.timestamp) shouldBe sorted
     extStepInterpolation.map(_.timestamp) shouldBe sorted
-    aggregates.keys should contain only (Seq("average", "stepInterpolation"):_*)
+    aggregates.keys should contain only ("average", "stepInterpolation")
     extAverages.head.value should equal(2.7346077636587798)
     extAverages.last.value should equal(2.7051279586700723)
     extStepInterpolation.last.value should equal(2.8424909114837646)
@@ -159,7 +160,7 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
     val extSum2 = extAggregates2("sum").head.datapoints
     val extStepInterpolation2 = extAggregates2("stepInterpolation").head.datapoints
     extSum2.map(_.timestamp).tail should contain theSameElementsInOrderAs extStepInterpolation2.map(_.timestamp)
-    aggregates2.keys should contain only (Seq("sum", "stepInterpolation"):_*)
+    aggregates2.keys should contain only ("sum", "stepInterpolation")
     assertThrows[CdpApiException] {
       val _ = client.dataPoints.queryAggregatesById(
         54577852743225L,
@@ -193,7 +194,7 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
     aggregates shouldBe empty
   }
 
-  val sumsOnly = client.dataPoints.queryAggregatesById(
+  private val sumsOnly = client.dataPoints.queryAggregatesById(
     54577852743225L,
     Instant.ofEpochMilli(0L),
     Instant.ofEpochMilli(1553795183461L),
@@ -211,7 +212,7 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
         Instant.ofEpochMilli(1553795183461L)
       )
     }
-    caught.missing.get.head.toMap("id").toString() shouldEqual missingId.toString
+    caught.missing.value.head.toMap("id").toString() shouldEqual missingId.toString
 
     val sCaught = intercept[CdpApiException] {
       client.dataPoints.queryById(
@@ -220,7 +221,7 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
         Instant.ofEpochMilli(1553795183461L)
       )
     }
-    sCaught.missing.get.head.toMap("id").toString() shouldEqual missingId.toString
+    sCaught.missing.value.head.toMap("id").toString() shouldEqual missingId.toString
 
     val aggregateCaught = intercept[CdpApiException] {
       client.dataPoints.queryAggregatesById(
@@ -231,7 +232,7 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
         Seq("average")
       )
     }
-    aggregateCaught.missing.get.head.toMap("id").toString() shouldEqual missingId.toString
+    aggregateCaught.missing.value.head.toMap("id").toString() shouldEqual missingId.toString
   }
 
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/DataSetsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/DataSetsTest.scala
@@ -7,6 +7,7 @@ import java.time.Instant
 import com.cognite.sdk.scala.common._
 import com.cognite.sdk.scala.common.SetValue
 
+@SuppressWarnings(Array("org.wartremover.warts.Null", "org.wartremover.warts.TraversableOps"))
 class DataSetsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
@@ -65,7 +66,7 @@ class DataSetsTest extends SdkTestSpec with ReadBehaviours with WritableBehavior
     datasetUpdates,
     (id: Long, item: DataSet) => item.copy(id = id),
     (a: DataSet, b: DataSet) => {
-      a.copy(lastUpdatedTime = Instant.ofEpochMilli(0)) == b.copy(lastUpdatedTime = Instant.ofEpochMilli(0))
+      a.copy(lastUpdatedTime = Instant.ofEpochMilli(0)) === b.copy(lastUpdatedTime = Instant.ofEpochMilli(0))
     },
     (readDatasets: Seq[DataSet], updatedDatasets: Seq[DataSet]) => {
       assert(datasetsToCreate.size == datasetUpdates.size)
@@ -74,11 +75,11 @@ class DataSetsTest extends SdkTestSpec with ReadBehaviours with WritableBehavior
       assert(updatedDatasets.zip(readDatasets).forall { case (updated, read) =>
         updated.description.nonEmpty &&
           read.description.nonEmpty &&
-          updated.description.forall { description => description == s"${read.description.get}-1"}
+          updated.description.forall { description => description === s"${read.description.value}-1"}
       })
       assert(readDatasets.head.name.isDefined)
       assert(updatedDatasets.head.name.isEmpty)
-      assert(updatedDatasets(1).name == datasetUpdates(1).name)
+      assert(updatedDatasets(1).name === datasetUpdates(1).name)
       ()
     }
   )
@@ -94,7 +95,9 @@ class DataSetsTest extends SdkTestSpec with ReadBehaviours with WritableBehavior
     ),
     (readDatasets: Seq[DataSet], updatedDatasets: Seq[DataSet]) => {
       assert(readDatasets.size == updatedDatasets.size)
-      assert(updatedDatasets.zip(readDatasets).forall { case (updated, read) =>  updated.description.get == s"${read.description.get}-1" })
+      assert(updatedDatasets.zip(readDatasets).forall { case (updated, read) =>
+        updated.description.value === s"${read.description.value}-1"
+      })
       val names = updatedDatasets.map(_.name)
       assert(List(None, None, None) === names)
       ()
@@ -113,8 +116,8 @@ class DataSetsTest extends SdkTestSpec with ReadBehaviours with WritableBehavior
     (readDatasets: Seq[DataSet], updatedDatasets: Seq[DataSet]) => {
       assert(readDatasets.size == updatedDatasets.size)
       assert(updatedDatasets.zip(readDatasets).forall { case (updated, read) =>
-        updated.description.getOrElse("") == s"${read.description.getOrElse("")}-1" })
-      assert(updatedDatasets.zip(readDatasets).forall { case (updated, read) => updated.externalId == read.externalId })
+        updated.description.getOrElse("") === s"${read.description.getOrElse("")}-1" })
+      assert(updatedDatasets.zip(readDatasets).forall { case (updated, read) => updated.externalId === read.externalId })
       ()
     }
   )

--- a/src/test/scala/com/cognite/sdk/scala/v1/EventsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/EventsTest.scala
@@ -8,6 +8,7 @@ import java.time.Instant
 import fs2._
 import com.cognite.sdk.scala.common.{ReadBehaviours, RetryWhile, SdkTestSpec, SetNull, SetValue, WritableBehaviors}
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.TraversableOps", "org.wartremover.warts.Null"))
 class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with RetryWhile {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
@@ -77,7 +78,7 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
     eventsToCreate,
     eventUpdates,
     (id: Long, item: Event) => item.copy(id = id),
-    (a: Event, b: Event) => { a == b },
+    (a: Event, b: Event) => { a === b },
     (readEvents: Seq[Event], updatedEvents: Seq[Event]) => {
       assert(eventsToCreate.size == eventUpdates.size)
       assert(readEvents.size == eventsToCreate.size)
@@ -85,11 +86,11 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
       assert(updatedEvents.zip(readEvents).forall { case (updated, read) =>
         updated.description.nonEmpty &&
           read.description.nonEmpty &&
-          updated.description.forall { description => description == s"${read.description.get}-1"}
+          updated.description.forall { description => description === s"${read.description.value}-1"}
       })
       assert(readEvents.head.subtype.isDefined)
       assert(updatedEvents.head.subtype.isEmpty)
-      assert(updatedEvents(1).subtype == eventUpdates(1).subtype)
+      assert(updatedEvents(1).subtype === eventUpdates(1).subtype)
       val dataSets = updatedEvents.map(_.dataSetId)
       assert(List(None, Some(testDataSet.id), Some(testDataSet.id)) === dataSets)
       ()
@@ -107,7 +108,9 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
     ),
     (readEvents: Seq[Event], updatedEvents: Seq[Event]) => {
       assert(readEvents.size == updatedEvents.size)
-      assert(updatedEvents.zip(readEvents).forall { case (updated, read) =>  updated.description.get == s"${read.description.get}-1" })
+      assert(updatedEvents.zip(readEvents).forall { case (updated, read) =>
+        updated.description.value === s"${read.description.value}-1"
+      })
       val dataSets = updatedEvents.map(_.dataSetId)
       assert(List(None, None, None) === dataSets)
       ()
@@ -122,10 +125,11 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
     Map("update-1-externalId" -> EventUpdate(description = Some(SetValue("description-1-1"))),
       "update-2-externalId" -> EventUpdate(description = Some(SetValue("description-2-1")))),
     (readEvents: Seq[Event], updatedEvents: Seq[Event]) => {
-      assert(readEvents.size == updatedEvents.size)
+      assert(readEvents.size === updatedEvents.size)
       assert(updatedEvents.zip(readEvents).forall { case (updated, read) =>
-        updated.description.getOrElse("") == s"${read.description.getOrElse("")}-1" })
-      assert(updatedEvents.zip(readEvents).forall { case (updated, read) => updated.externalId == read.externalId })
+        updated.description.getOrElse("") === s"${read.description.getOrElse("")}-1"
+      })
+      assert(updatedEvents.zip(readEvents).forall { case (updated, read) => updated.externalId === read.externalId })
       ()
     }
   )
@@ -138,8 +142,8 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
       Map(createEvents.head.id -> EventUpdate(description = Some(SetValue("description-1-1"))),
         createEvents.tail.head.id -> EventUpdate(description = Some(SetValue("description-2-1")))))
     assert(updatedEvents.zip(createEvents).forall {
-      case (updated, read) => updated.description.get == s"${read.description.get}-1" })
-    assert(updatedEvents.zip(createEvents).forall { case (updated, read) => updated.id == read.id })
+      case (updated, read) => updated.description.value === s"${read.description.value}-1" })
+    assert(updatedEvents.zip(createEvents).forall { case (updated, read) => updated.id === read.id })
   }
 
   it should "support filter" in {
@@ -285,7 +289,7 @@ class EventsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors 
         a => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
-      created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)
+      created.filter(_.dataSetId.isDefined).map(_.id) should contain theSameElementsAs foundItems.map(_.id)
     } finally {
       client.events.deleteByIds(created.map(_.id))
     }

--- a/src/test/scala/com/cognite/sdk/scala/v1/FunctionsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/FunctionsTest.scala
@@ -3,11 +3,13 @@
 
 package com.cognite.sdk.scala.v1
 
+import cats.catsInstancesForId
 import io.circe.Json
 import org.scalatest.Inspectors._
 import io.circe.JsonObject
 import com.cognite.sdk.scala.common._
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements"))
 class FunctionsTest extends SdkTestSpec with ReadBehaviours {
   override lazy val client: GenericClient[cats.Id] = GenericClient.forAuth[cats.Id](
     "playground", auth, apiVersion = Some("playground"))(implicitly, sttpBackend)

--- a/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/GreenfieldDataPointsTest.scala
@@ -6,6 +6,7 @@ package com.cognite.sdk.scala.v1
 import java.util.UUID
 import com.cognite.sdk.scala.common.{DataPointsResourceBehaviors, SdkTestSpec}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class GreenfieldDataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
   override def withTimeSeries(testCode: TimeSeries => Any): Unit = {
     val name = Some(s"data-points-test-${UUID.randomUUID().toString}")

--- a/src/test/scala/com/cognite/sdk/scala/v1/LabelsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/LabelsTest.scala
@@ -4,6 +4,7 @@
 package com.cognite.sdk.scala.v1
 import com.cognite.sdk.scala.common.{ReadBehaviours, RetryWhile, SdkTestSpec, WritableBehaviors}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements"))
 class LabelsTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with RetryWhile {
   private val externalIdsThatDoNotExist = Seq("5PNii0w4GCDBvXPZ", "6VhKQqtTJqBHGulw")
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/ProjectTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ProjectTest.scala
@@ -5,6 +5,7 @@ package com.cognite.sdk.scala.v1
 
 import com.cognite.sdk.scala.common.SdkTestSpec
 
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements"))
 class ProjectTest extends SdkTestSpec {
   // TODO: We don't have sufficient permissions in publicdata or Greenfield
   "Project" should "be retrievable and correct" ignore {

--- a/src/test/scala/com/cognite/sdk/scala/v1/RawTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/RawTest.scala
@@ -4,11 +4,14 @@
 package com.cognite.sdk.scala.v1
 
 import cats.syntax.either._
+import cats.catsInstancesForId
 import com.cognite.sdk.scala.common.{ReadBehaviours, SdkTestSpec, WritableBehaviors}
 import fs2.Stream
 import io.circe.syntax._
+import org.scalatest.OptionValues
 
-class RawTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements"))
+class RawTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with OptionValues {
   private val idsThatDoNotExist = Seq("nodatabase", "randomdatabase")
 
   it should behave like readable(client.rawDatabases)
@@ -86,7 +89,7 @@ class RawTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
     // while avoiding deprecation warnings on Scala 2.13, which does not need that import.
     // use it for some nonsense here to make the import "used" also for Scala 2.13
     val either: Either[String, String] = Either.right("asdf")
-    assert(either.forall(_ == "asdf"))
+    assert(either.forall(_ === "asdf"))
 
     val rowsResponseAfterCreate = rows.list().compile.toList
     assert(rowsResponseAfterCreate.size === 2)
@@ -144,7 +147,7 @@ class RawTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors {
       val currentRows = rows.list().compile.toList
       assert(currentRows.length === 4)
 
-      val maxLastUpdatedTime = prevRows.map(_.lastUpdatedTime.get).max
+      val maxLastUpdatedTime = prevRows.map(_.lastUpdatedTime.value).max
       assert(
         rows
           .filter(RawRowFilter(minLastUpdatedTime = Some(maxLastUpdatedTime)))

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequenceRowsTest.scala
@@ -6,9 +6,10 @@ package com.cognite.sdk.scala.v1
 import cats.data.NonEmptyList
 import com.cognite.sdk.scala.common._
 import io.circe.syntax._
-import org.scalatest.ParallelTestExecution
+import org.scalatest.{OptionValues, ParallelTestExecution}
 
-class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with RetryWhile {
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements"))
+class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with RetryWhile with OptionValues {
   def withSequence(testCode: Sequence => Any): Unit = {
     val externalId = shortRandom()
     val sequence = client.sequences.createOneFromRead(
@@ -79,7 +80,7 @@ class SequenceRowsTest extends SdkTestSpec with ParallelTestExecution with Retry
   }
 
   it should "be possible to insert, update and delete sequence rows using externalId" in withSequence { sequence =>
-    val externalId = sequence.externalId.get
+    val externalId = sequence.externalId.value
     client.sequenceRows.insertByExternalId(externalId, sequence.columns.map(_.externalId.getOrElse(
       throw new RuntimeException("Unexpected missing column externalId"))).toList, testRows)
     val rows = retryWithExpectedResult[Seq[SequenceRow]](

--- a/src/test/scala/com/cognite/sdk/scala/v1/SequencesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SequencesTest.scala
@@ -8,10 +8,11 @@ import java.time.Instant
 import cats.data.NonEmptyList
 import com.cognite.sdk.scala.common.{ReadBehaviours, RetryWhile, SdkTestSpec, SetNull, SetValue, WritableBehaviors}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps", "org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Null"))
 class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with RetryWhile {
   private val idsThatDoNotExist = Seq(999991L, 999992L)
   private val externalIdsThatDoNotExist = Seq("sequence-5PNii0w", "sequence-6VhKQqt")
-  val eid = shortRandom()
+  private val eid = shortRandom()
 
   (it should behave).like(readable(client.sequences))
 
@@ -147,7 +148,7 @@ class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehavio
       sequencesUpdates,
       (id: Long, item: Sequence) => item.copy(id = id),
       (a: Sequence, b: Sequence) => {
-        a.copy(lastUpdatedTime = Instant.ofEpochMilli(0)) == b.copy(
+        a.copy(lastUpdatedTime = Instant.ofEpochMilli(0)) === b.copy(
           lastUpdatedTime = Instant.ofEpochMilli(0)
         )
       },
@@ -156,10 +157,10 @@ class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehavio
         assert(readSequence.size == sequencesToCreate.size)
         assert(updatedSequence.size == sequencesUpdates.size)
         assert(updatedSequence.zip(readSequence).forall {
-          case (updated, read) => updated.name == read.name.map(n => s"${n}-1")
+          case (updated, read) => updated.name === read.name.map(n => s"${n}-1")
         })
         assert(updatedSequence.head.description.isEmpty)
-        assert(updatedSequence(1).description == sequencesUpdates(1).description)
+        assert(updatedSequence(1).description === sequencesUpdates(1).description)
         val dataSets = updatedSequence.map(_.dataSetId)
         assert(List(None, Some(testDataSet.id), Some(testDataSet.id)) === dataSets)
         ()
@@ -178,7 +179,9 @@ class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehavio
     ),
     (readSequences: Seq[Sequence], updatedSequences: Seq[Sequence]) => {
       assert(readSequences.size == updatedSequences.size)
-      assert(updatedSequences.zip(readSequences).forall { case (updated, read) =>  updated.name.get == s"${read.name.get}-1" })
+      assert(updatedSequences.zip(readSequences).forall { case (updated, read) =>
+        updated.name.value === s"${read.name.value}-1"
+      })
       val dataSets = updatedSequences.map(_.dataSetId)
       assert(List(None, Some(testDataSet.id), None) === dataSets)
       ()
@@ -198,7 +201,7 @@ class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehavio
     (readSequences: Seq[Sequence], updatedSequences: Seq[Sequence]) => {
       assert(readSequences.size == updatedSequences.size)
       assert(updatedSequences.zip(readSequences).forall { case (updated, read) =>
-        updated.externalId.getOrElse("") == s"${read.externalId.getOrElse("")}-1" })
+        updated.externalId.getOrElse("") === s"${read.externalId.getOrElse("")}-1" })
       ()
     }
   )
@@ -311,7 +314,7 @@ class SequencesTest extends SdkTestSpec with ReadBehaviours with WritableBehavio
         (a: Seq[_]) => a should not be empty
       )
       foundItems.map(_.dataSetId) should contain only Some(testDataSet.id)
-      created.filter(_.dataSetId.isDefined).map(_.id) should contain only (foundItems.map(_.id): _*)
+      created.filter(_.dataSetId.isDefined).map(_.id) should contain theSameElementsAs foundItems.map(_.id)
     } finally {
       client.sequences.deleteByIds(created.map(_.id))
     }

--- a/src/test/scala/com/cognite/sdk/scala/v1/StringDataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/StringDataPointsTest.scala
@@ -6,6 +6,7 @@ package com.cognite.sdk.scala.v1
 import java.util.UUID
 import com.cognite.sdk.scala.common.{SdkTestSpec, StringDataPointsResourceBehaviors}
 
+@SuppressWarnings(Array("org.wartremover.warts.TraversableOps"))
 class StringDataPointsTest extends SdkTestSpec with StringDataPointsResourceBehaviors {
   override def withStringTimeSeries(testCode: TimeSeries => Any): Unit = {
     val name = Some(s"string-data-points-test-${UUID.randomUUID().toString}")


### PR DESCRIPTION
Remove Wartremover exclusions, fix Wartremover errors.

IntelliJ doesn't play well with Wartremover exclusions, so suppress
the warnings that aren't relevant for tests, and fix the other
complaints it had.

Remove dependency on Chimney, as it doesn't support Scala 3.
Use manual conversions (at least for now) instead.

Use Java protobuf classes, as it removes the dependency on scalapb
runtime which no longer supports Scala 2.11, and we would need newer
versions to support Scala 3.