### PR TITLE
Generalize the WithExternalId trait

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/dataTypes.scala
@@ -9,7 +9,7 @@ import com.cognite.sdk.scala.v1.CogniteId
 import io.circe.{Decoder, Encoder, Json, JsonObject}
 import io.circe.generic.semiauto.deriveDecoder
 import sttp.model.Uri
-
+// scalastyle:off number.of.types
 trait ResponseWithCursor {
   val nextCursor: Option[String]
 }
@@ -150,9 +150,12 @@ trait WithId[I] {
   val id: I
 }
 
-trait WithExternalIdGeneric[F[_]] {
+trait WithGetExternalId {
+  def getExternalId(): Option[String]
+}
+
+trait WithExternalIdGeneric[F[_]] extends WithGetExternalId {
   val externalId: F[String]
-  def getExternalId(): Option[String] // We could have implemented Foldable instead
 }
 
 trait WithExternalId extends WithExternalIdGeneric[Option] {
@@ -167,8 +170,13 @@ trait WithCreatedTime {
   val createdTime: Instant
 }
 
-trait WithSetExternalId {
+trait WithSetExternalId extends WithGetExternalId {
   val externalId: Option[Setter[String]]
+  override def getExternalId(): Option[String] =
+    externalId match {
+      case Some(SetValue(v)) => Some(v)
+      case _ => None
+    }
 }
 
 trait ToCreate[W] {


### PR DESCRIPTION
for usage in the spark upsert schemas. Not necessary, but would remove the strict dependency on OptionalField here: https://github.com/cognitedata/cdp-spark-datasource/pull/500/files#diff-9de35abaddac5206711ca0f28ad3ba12c66276eba2c9cb8982870993d992f36cR73