### PR TITLE
Use DataPoints by CogniteId intead of separate methods for id and externalId

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/dataPoints.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataPoints.scala
@@ -4,29 +4,43 @@
 package com.cognite.sdk.scala.v1
 
 import com.cognite.sdk.scala.common.{AggregateDataPoint, DataPoint, StringDataPoint}
+import io.circe.syntax.EncoderOps
+import io.circe.{Encoder, Json}
 
 final case class DataPointsByExternalId(
     externalId: String,
     datapoints: Seq[DataPoint]
 )
 
+trait DataPointsResponse[D] {
+  def id: Long
+  def getExternalId: Option[String]
+  def isString: Boolean
+  def unit: Option[String]
+  def datapoints: Seq[D]
+}
+
 final case class DataPointsByIdResponse(
     id: Long,
     externalId: Option[String],
     isString: Boolean,
-    isStep: Boolean,
+    isStep: Boolean = true, // default value for accidental string points read
     unit: Option[String],
     datapoints: Seq[DataPoint]
-)
+) extends DataPointsResponse[DataPoint] {
+  override def getExternalId: Option[String] = externalId
+}
 
 final case class DataPointsByExternalIdResponse(
     id: Long,
     externalId: String,
     isString: Boolean,
-    isStep: Boolean,
+    isStep: Boolean = true, // default value for accidental string points read
     unit: Option[String],
     datapoints: Seq[DataPoint]
-)
+) extends DataPointsResponse[DataPoint] {
+  override def getExternalId: Option[String] = Some(externalId)
+}
 
 final case class StringDataPointsByIdResponse(
     id: Long,
@@ -34,7 +48,9 @@ final case class StringDataPointsByIdResponse(
     isString: Boolean,
     unit: Option[String],
     datapoints: Seq[StringDataPoint]
-)
+) extends DataPointsResponse[StringDataPoint] {
+  override def getExternalId: Option[String] = externalId
+}
 
 final case class StringDataPointsByExternalIdResponse(
     id: Long,
@@ -42,44 +58,56 @@ final case class StringDataPointsByExternalIdResponse(
     isString: Boolean,
     unit: Option[String],
     datapoints: Seq[StringDataPoint]
-)
+) extends DataPointsResponse[StringDataPoint] {
+  override def getExternalId: Option[String] = Some(externalId)
+}
 
 final case class StringDataPointsByExternalId(
     externalId: String,
     datapoints: Seq[StringDataPoint]
 )
 
-sealed trait DeleteDataPointsRange
-
-final case class DeleteRangeById(
-    id: Long,
+final case class DeleteDataPointsRange(
+    id: CogniteId,
     inclusiveBegin: Long,
     exclusiveEnd: Long
-) extends DeleteDataPointsRange
+)
+object DeleteDataPointsRange {
+  implicit val encoder: Encoder[DeleteDataPointsRange] = Encoder.instance(v =>
+    Json.obj(
+      "inclusiveBegin" -> Json.fromLong(v.inclusiveBegin),
+      "exclusiveEnd" -> Json.fromLong(v.exclusiveEnd),
+      v.id match {
+        case CogniteExternalId(externalId) => "externalId" -> Json.fromString(externalId)
+        case CogniteInternalId(id) => "id" -> Json.fromLong(id)
+      }
+    )
+  )
+}
 
-final case class DeleteRangeByExternalId(
-    externalId: String,
-    inclusiveBegin: Long,
-    exclusiveEnd: Long
-) extends DeleteDataPointsRange
-
-final case class QueryRangeById(
-    id: Long,
+final case class QueryDataPointsRange(
+    id: CogniteId,
     start: String,
     end: String,
     limit: Option[Int] = None,
     granularity: Option[String] = None,
     aggregates: Option[Seq[String]] = None
 )
-
-final case class QueryRangeByExternalId(
-    externalId: String,
-    start: String,
-    end: String,
-    limit: Option[Int] = None,
-    granularity: Option[String] = None,
-    aggregates: Option[Seq[String]] = None
-)
+object QueryDataPointsRange {
+  implicit val encoder: Encoder[QueryDataPointsRange] = Encoder.instance(v =>
+    Json.obj(
+      "start" -> Json.fromString(v.start),
+      "end" -> Json.fromString(v.end),
+      "limit" -> v.limit.asJson,
+      "granularity" -> v.granularity.asJson,
+      "aggregates" -> v.aggregates.asJson,
+      v.id match {
+        case CogniteExternalId(externalId) => "externalId" -> Json.fromString(externalId)
+        case CogniteInternalId(id) => "id" -> Json.fromLong(id)
+      }
+    )
+  )
+}
 
 final case class QueryAggregatesResponse(
     id: Long,

--- a/src/main/scala/com/cognite/sdk/scala/v1/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataTypes.scala
@@ -3,12 +3,39 @@
 
 package com.cognite.sdk.scala.v1
 
+import cats.implicits._
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
+
 import java.time.Instant
 
 sealed trait CogniteId
 
 final case class CogniteExternalId(externalId: String) extends CogniteId
 final case class CogniteInternalId(id: Long) extends CogniteId
+
+object CogniteExternalId {
+  implicit val encoder: Encoder[CogniteExternalId] = deriveEncoder
+  implicit val decoder: Decoder[CogniteExternalId] = deriveDecoder
+}
+object CogniteInternalId {
+  implicit val encoder: Encoder[CogniteInternalId] = deriveEncoder
+  implicit val decoder: Decoder[CogniteInternalId] = deriveDecoder
+}
+object CogniteId {
+  implicit val encoder: Encoder[CogniteId] = Encoder.instance {
+    case id @ CogniteExternalId(_) => CogniteExternalId.encoder(id)
+    case id @ CogniteInternalId(_) => CogniteInternalId.encoder(id)
+  }
+  @SuppressWarnings(
+    Array("org.wartremover.warts.TraversableOps")
+  )
+  implicit val decoder: Decoder[CogniteId] =
+    List[Decoder[CogniteId]](
+      Decoder[CogniteInternalId].widen,
+      Decoder[CogniteExternalId].widen
+    ).reduceLeft(_ or _)
+}
 
 // min and max need to be optional, since one of them can be provided alone.
 final case class TimeRange(min: Option[Instant] = None, max: Option[Instant] = None)

--- a/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/DataPointsTest.scala
@@ -182,8 +182,8 @@ class DataPointsTest extends SdkTestSpec with DataPointsResourceBehaviors {
   }
 
   it should "be possible to query aggregate values with ignoreUnknownIds" in {
-    val aggregates = client.dataPoints.queryAggregatesByIds(
-      Seq(123L),
+    val aggregates = client.dataPoints.queryAggregates(
+      Seq(CogniteInternalId(123L)),
       Instant.ofEpochMilli(0L),
       Instant.ofEpochMilli(1553795183461L),
       "1d",

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -307,7 +307,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     val endTime = startTime + 20*1000
     val dp = (startTime to endTime by 1000).map(t =>
         DataPoint(Instant.ofEpochMilli(t), java.lang.Math.random()))
-    client.dataPoints.insertById(timeSeriesID, dp)
+    client.dataPoints.insert(CogniteInternalId(timeSeriesID), dp)
     retryWithExpectedResult[DataPointsByIdResponse](
       client.dataPoints.queryById(
         timeSeriesID, Instant.ofEpochMilli(startTime), Instant.ofEpochMilli(endTime + 1000)),


### PR DESCRIPTION
This should simplify code in Spark DataSource that now has to handle
ids and externalIds separately. It also reduces the API surface
of this SDK.

This is the code that handles these two ids separately just because the SDK has separate methods for them: https://github.com/cognitedata/cdp-spark-datasource/blob/master/src/main/scala/cognite/spark/v1/NumericDataPointsRdd.scala#L276

Is it ok to remove existing methods like this? Would you mind to change other resource types in a similar way?