### PR TITLE
Move DomainSpecificLanguageFilter to a separate file

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/DomainSpecificLanguageFilter.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/DomainSpecificLanguageFilter.scala
@@ -1,0 +1,121 @@
+// Copyright 2020 Cognite AS
+// SPDX-License-Identifier: Apache-2.0
+
+package com.cognite.sdk.scala.common
+
+import com.cognite.sdk.scala.v1._
+import io.circe._
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.syntax._
+
+sealed trait DomainSpecificLanguageFilter
+
+case object EmptyFilter extends DomainSpecificLanguageFilter
+
+sealed trait DSLBoolFilter extends DomainSpecificLanguageFilter
+final case class DSLAndFilter(and: Seq[DomainSpecificLanguageFilter]) extends DSLBoolFilter
+final case class DSLOrFilter(or: Seq[DomainSpecificLanguageFilter]) extends DSLBoolFilter
+final case class DSLNotFilter(not: DomainSpecificLanguageFilter) extends DSLBoolFilter
+
+sealed trait DSLLeafFilter extends DomainSpecificLanguageFilter
+final case class DSLEqualsFilter(property: Seq[String], value: DataModelProperty[_])
+    extends DSLLeafFilter
+final case class DSLInFilter(property: Seq[String], values: Seq[DataModelProperty[_]])
+    extends DSLLeafFilter
+final case class DSLRangeFilter(
+    property: Seq[String],
+    gte: Option[DataModelProperty[_]] = None,
+    gt: Option[DataModelProperty[_]] = None,
+    lte: Option[DataModelProperty[_]] = None,
+    lt: Option[DataModelProperty[_]] = None
+) extends DSLLeafFilter {
+  require(
+    !(gte.isDefined && gt.isDefined) && // can't have both upper bound in the same time
+      !(lte.isDefined && lt.isDefined) && // can't have both lower bound in the same time
+      (gte.isDefined || gt.isDefined || lte.isDefined || lt.isDefined) // at least one bound must be defined
+  )
+}
+final case class DSLPrefixFilter(property: Seq[String], value: DataModelProperty[_])
+    extends DSLLeafFilter
+final case class DSLExistsFilter(property: Seq[String]) extends DSLLeafFilter
+final case class DSLContainsAnyFilter(property: Seq[String], values: Seq[DataModelProperty[_]])
+    extends DSLLeafFilter
+final case class DSLContainsAllFilter(property: Seq[String], values: Seq[DataModelProperty[_]])
+    extends DSLLeafFilter
+
+object DomainSpecificLanguageFilter {
+
+  // scalastyle:off cyclomatic.complexity
+  implicit val propEncoder: Encoder[DataModelProperty[_]] = {
+    case b: PropertyType.Boolean.Property => b.value.asJson
+    case i: PropertyType.Int.Property => i.value.asJson
+    case bi: PropertyType.Bigint.Property => bi.value.asJson
+    case f: PropertyType.Float32.Property => f.value.asJson
+    case d: PropertyType.Float64.Property => d.value.asJson
+    case bd: PropertyType.Numeric.Property => bd.value.asJson
+    case s: PropertyType.Text.Property => s.value.asJson
+    case j: PropertyType.Json.Property => j.value.asJson
+    case ts: PropertyType.Timestamp.Property => ts.value.asJson
+    case d: PropertyType.Date.Property => d.value.asJson
+    case gm: PropertyType.Geometry.Property => gm.value.asJson
+    case gg: PropertyType.Geography.Property => gg.value.asJson
+    case dr: PropertyType.DirectRelation.Property => dr.value.asJson
+    case b: PropertyType.Array.Boolean.Property => b.value.asJson
+    case i: PropertyType.Array.Int.Property => i.value.asJson
+    case bi: PropertyType.Array.Bigint.Property => bi.value.asJson
+    case f: PropertyType.Array.Float32.Property => f.value.asJson
+    case d: PropertyType.Array.Float64.Property => d.value.asJson
+    case bd: PropertyType.Array.Numeric.Property => bd.value.asJson
+    case s: PropertyType.Array.Text.Property => s.value.asJson
+    case j: PropertyType.Array.Json.Property => j.value.asJson
+    case ts: PropertyType.Array.Timestamp.Property => ts.value.asJson
+    case d: PropertyType.Array.Date.Property => d.value.asJson
+    case gm: PropertyType.Array.Geometry.Property => gm.value.asJson
+    case gg: PropertyType.Array.Geography.Property => gg.value.asJson
+    case _ => throw new Exception("unknown property type")
+  }
+
+  implicit val andFilterEncoder: Encoder[DSLAndFilter] = deriveEncoder[DSLAndFilter]
+  implicit val orFilterEncoder: Encoder[DSLOrFilter] = deriveEncoder[DSLOrFilter]
+  implicit val notFilterEncoder: Encoder[DSLNotFilter] = deriveEncoder[DSLNotFilter]
+
+  implicit val equalsFilterEncoder: Encoder[DSLEqualsFilter] =
+    Encoder.forProduct2[DSLEqualsFilter, Seq[String], DataModelProperty[_]]("property", "value")(
+      dmiEqF => (dmiEqF.property, dmiEqF.value)
+    )
+  implicit val inFilterEncoder: Encoder[DSLInFilter] = deriveEncoder[DSLInFilter]
+  implicit val rangeFilterEncoder: Encoder[DSLRangeFilter] =
+    deriveEncoder[DSLRangeFilter].mapJson(_.dropNullValues) // VH TODO make this common
+
+  implicit val prefixFilterEncoder: Encoder[DSLPrefixFilter] =
+    Encoder.forProduct2[DSLPrefixFilter, Seq[String], DataModelProperty[_]]("property", "value")(
+      dmiPxF => (dmiPxF.property, dmiPxF.value)
+    )
+  implicit val existsFilterEncoder: Encoder[DSLExistsFilter] = deriveEncoder[DSLExistsFilter]
+  implicit val containsAnyFilterEncoder: Encoder[DSLContainsAnyFilter] =
+    deriveEncoder[DSLContainsAnyFilter]
+  implicit val containsAllFilterEncoder: Encoder[DSLContainsAllFilter] =
+    deriveEncoder[DSLContainsAllFilter]
+
+  implicit val filterEncoder: Encoder[DomainSpecificLanguageFilter] = {
+    case EmptyFilter =>
+      Json.fromFields(Seq.empty)
+    case b: DSLBoolFilter =>
+      b match {
+        case f: DSLAndFilter => f.asJson
+        case f: DSLOrFilter => f.asJson
+        case f: DSLNotFilter => f.asJson
+      }
+    case l: DSLLeafFilter =>
+      l match {
+        case f: DSLInFilter => Json.obj(("in", f.asJson))
+        case f: DSLEqualsFilter => Json.obj(("equals", f.asJson))
+        case f: DSLRangeFilter => Json.obj(("range", f.asJson))
+        case f: DSLPrefixFilter => Json.obj(("prefix", f.asJson))
+        case f: DSLExistsFilter => Json.obj(("exists", f.asJson))
+        case f: DSLContainsAnyFilter => Json.obj(("containsAny", f.asJson))
+        case f: DSLContainsAllFilter => Json.obj(("containsAll", f.asJson))
+      }
+  }
+
+}

--- a/src/main/scala/com/cognite/sdk/scala/v1/propertyMap.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/propertyMap.scala
@@ -1,5 +1,7 @@
 package com.cognite.sdk.scala.v1
 
+import com.cognite.sdk.scala.common.{DomainSpecificLanguageFilter, EmptyFilter}
+
 sealed class PropertyMap(val allProperties: Map[String, DataModelProperty[_]]) {
   val externalId: String = allProperties.get("externalId") match {
     case Some(PropertyType.Text.Property(externalId)) => externalId
@@ -41,41 +43,6 @@ final case class DataModelNodeCreate(
     overwrite: Boolean = false,
     items: Seq[PropertyMap]
 )
-
-sealed trait DomainSpecificLanguageFilter
-
-case object EmptyFilter extends DomainSpecificLanguageFilter
-
-sealed trait DMIBoolFilter extends DomainSpecificLanguageFilter
-final case class DMIAndFilter(and: Seq[DomainSpecificLanguageFilter]) extends DMIBoolFilter
-final case class DMIOrFilter(or: Seq[DomainSpecificLanguageFilter]) extends DMIBoolFilter
-final case class DMINotFilter(not: DomainSpecificLanguageFilter) extends DMIBoolFilter
-
-sealed trait DMILeafFilter extends DomainSpecificLanguageFilter
-final case class DMIEqualsFilter(property: Seq[String], value: DataModelProperty[_])
-    extends DMILeafFilter
-final case class DMIInFilter(property: Seq[String], values: Seq[DataModelProperty[_]])
-    extends DMILeafFilter
-final case class DMIRangeFilter(
-    property: Seq[String],
-    gte: Option[DataModelProperty[_]] = None,
-    gt: Option[DataModelProperty[_]] = None,
-    lte: Option[DataModelProperty[_]] = None,
-    lt: Option[DataModelProperty[_]] = None
-) extends DMILeafFilter {
-  require(
-    !(gte.isDefined && gt.isDefined) && // can't have both upper bound in the same time
-      !(lte.isDefined && lt.isDefined) && // can't have both lower bound in the same time
-      (gte.isDefined || gt.isDefined || lte.isDefined || lt.isDefined) // at least one bound must be defined
-  )
-}
-final case class DMIPrefixFilter(property: Seq[String], value: DataModelProperty[_])
-    extends DMILeafFilter
-final case class DMIExistsFilter(property: Seq[String]) extends DMILeafFilter
-final case class DMIContainsAnyFilter(property: Seq[String], values: Seq[DataModelProperty[_]])
-    extends DMILeafFilter
-final case class DMIContainsAllFilter(property: Seq[String], values: Seq[DataModelProperty[_]])
-    extends DMILeafFilter
 
 final case class DataModelInstanceQuery(
     model: DataModelIdentifier,

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/dataModels.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/dataModels.scala
@@ -148,7 +148,7 @@ object DataModels {
     )
   implicit val dataModelPropertyIndexesDecoder: Decoder[DataModelIndexes] =
     deriveDecoder[DataModelIndexes]
-  implicit val dataModelPropertyDeffinitionDecoder: Decoder[DataModelPropertyDefinition] =
+  implicit val dataModelPropertyDefinitionDecoder: Decoder[DataModelPropertyDefinition] =
     Decoder.forProduct3("type", "nullable", "targetModel")(DataModelPropertyDefinition.apply)
   implicit val uniquenessConstraintDecoder: Decoder[UniquenessConstraint] =
     new Decoder[UniquenessConstraint] {

--- a/src/test/scala/com/cognite/sdk/scala/common/DataModelPropertiesSerializerTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/DataModelPropertiesSerializerTest.scala
@@ -4,6 +4,7 @@
 package com.cognite.sdk.scala.common
 
 import com.cognite.sdk.scala.v1._
+import com.cognite.sdk.scala.v1.resources.Nodes.createDynamicPropertyDecoder
 import io.circe
 import io.circe.CursorOp.DownField
 import io.circe.{Decoder, DecodingFailure, HCursor, Json}
@@ -11,6 +12,7 @@ import io.circe.parser.decode
 import io.circe.syntax._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
+
 import java.time.{LocalDate, ZoneOffset, ZonedDateTime}
 
 @SuppressWarnings(
@@ -41,12 +43,13 @@ class DataModelPropertiesSerializerTest extends AnyWordSpec with Matchers {
     "arr_empty_nullable" -> DataModelPropertyDefinition(PropertyType.Array.Float64)
   )
 
-  import com.cognite.sdk.scala.v1.resources.Nodes._
 
   implicit val propertyTypeDecoder: Decoder[PropertyMap] =
     createDynamicPropertyDecoder(props)
 
-  implicit val dataModelInstanceQueryResponseDecoder: Decoder[DataModelInstanceQueryResponse] =
+  implicit val dataModelInstanceQueryResponseDecoder: Decoder[DataModelInstanceQueryResponse] = {
+    import com.cognite.sdk.scala.v1.resources.Nodes.dataModelPropertyDefinitionDecoder
+
     new Decoder[DataModelInstanceQueryResponse] {
       def apply(c: HCursor): Decoder.Result[DataModelInstanceQueryResponse] =
         for {
@@ -55,6 +58,7 @@ class DataModelPropertiesSerializerTest extends AnyWordSpec with Matchers {
           nextCursor <- c.downField("nextCursor").as[Option[String]]
         } yield DataModelInstanceQueryResponse(items, modelProperties, nextCursor)
     }
+  }
 
   private def checkErrorDecodingOnField(
       res: Either[circe.Error, DataModelInstanceQueryResponse],

--- a/src/test/scala/com/cognite/sdk/scala/common/DomainSpecificLanguageFilterSerializerTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/DomainSpecificLanguageFilterSerializerTest.scala
@@ -20,7 +20,7 @@ import io.circe.parser._
 )
 class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matchers {
 
-  import com.cognite.sdk.scala.v1.resources.Nodes._
+  import DomainSpecificLanguageFilter._
 
   "DataModelFilterSerializer" when {
     "encode EmptyFilter" should {
@@ -31,7 +31,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
     }
     "encode LeafFilter" should {
       "work for equals filter" in {
-        val equalInt = DMIEqualsFilter(Seq("name", "tag"), PropertyType.Int.Property(1)).asJson
+        val equalInt = DSLEqualsFilter(Seq("name", "tag"), PropertyType.Int.Property(1)).asJson
         equalInt.toString() shouldBe """{
                                        |  "property" : [
                                        |    "name",
@@ -40,7 +40,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
                                        |  "value" : 1
                                        |}""".stripMargin
 
-        val equalString = DMIEqualsFilter(Seq("name", "tag"), PropertyType.Text.Property("abcdef")).asJson
+        val equalString = DSLEqualsFilter(Seq("name", "tag"), PropertyType.Text.Property("abcdef")).asJson
         equalString.toString() shouldBe """{
                                           |  "property" : [
                                           |    "name",
@@ -49,7 +49,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
                                           |  "value" : "abcdef"
                                           |}""".stripMargin
 
-        val equalBool = DMIEqualsFilter(Seq("name", "tag"), PropertyType.Boolean.Property(false)).asJson
+        val equalBool = DSLEqualsFilter(Seq("name", "tag"), PropertyType.Boolean.Property(false)).asJson
         equalBool.toString() shouldBe """{
                                         |  "property" : [
                                         |    "name",
@@ -59,7 +59,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
                                         |}""".stripMargin
       }
       "work for in filter" in {
-        val in = DMIInFilter(
+        val in = DSLInFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Bigint.Property(BigInt("123456789123456789123456789")),
@@ -83,24 +83,24 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
 
       }
       "work for range filter" in {
-        the[IllegalArgumentException] thrownBy DMIRangeFilter(
+        the[IllegalArgumentException] thrownBy DSLRangeFilter(
           Seq("name", "tag")
         )
 
-        the[IllegalArgumentException] thrownBy DMIRangeFilter(
+        the[IllegalArgumentException] thrownBy DSLRangeFilter(
           Seq("name", "tag"),
           gte = Some(PropertyType.Int.Property(1)),
           gt = Some(PropertyType.Int.Property(2))
         )
 
-        the[IllegalArgumentException] thrownBy DMIRangeFilter(
+        the[IllegalArgumentException] thrownBy DSLRangeFilter(
           Seq("name", "tag"),
           lte = Some(PropertyType.Text.Property("abc")),
           lt = Some(PropertyType.Text.Property("def"))
         )
 
         val range =
-          DMIRangeFilter(
+          DSLRangeFilter(
             Seq("name", "tag"),
             gte = Some(PropertyType.Int.Property(1)),
             lt = Some(PropertyType.Int.Property(2))
@@ -117,7 +117,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
 
       }
       "work for prefix filter" in {
-        val prefix = DMIPrefixFilter(Seq("name", "tag"), PropertyType.Text.Property("abc")).asJson
+        val prefix = DSLPrefixFilter(Seq("name", "tag"), PropertyType.Text.Property("abc")).asJson
         prefix.toString() shouldBe """{
                                  |  "property" : [
                                  |    "name",
@@ -128,7 +128,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
 
       }
       "work for exists filter" in {
-        val exists = DMIExistsFilter(Seq("name", "tag")).asJson
+        val exists = DSLExistsFilter(Seq("name", "tag")).asJson
         exists.toString() shouldBe """{
                                      |  "property" : [
                                      |    "name",
@@ -138,7 +138,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
 
       }
       "work for containsAny filter" in {
-        val containsAny = DMIContainsAnyFilter(
+        val containsAny = DSLContainsAnyFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Text.Property("abcdef"),
@@ -158,7 +158,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
       }
 
       "work for containsAll filter" in {
-        val containsAll = DMIContainsAllFilter(
+        val containsAll = DSLContainsAllFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Int.Property(1),
@@ -180,8 +180,8 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
 
     "encode BoolFilter" should {
       "work for and filter" in {
-        val equalInt = DMIEqualsFilter(Seq("name", "tag"), PropertyType.Int.Property(1))
-        val in = DMIInFilter(
+        val equalInt = DSLEqualsFilter(Seq("name", "tag"), PropertyType.Int.Property(1))
+        val in = DSLInFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Int.Property(1),
@@ -191,7 +191,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
           )
         )
 
-        val and = DMIAndFilter(Seq(equalInt, in)).asJson
+        val and = DSLAndFilter(Seq(equalInt, in)).asJson
         and.toString() shouldBe """{
                                   |  "and" : [
                                   |    {
@@ -222,15 +222,15 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
       }
       "work for or filter" in {
         val range =
-          DMIRangeFilter(
+          DSLRangeFilter(
             Seq("name", "tag"),
             gte = Some(PropertyType.Int.Property(1)),
             lt = Some(PropertyType.Int.Property(2))
           )
-        val prefix = DMIPrefixFilter(Seq("name", "tag"), PropertyType.Text.Property("abc"))
-        val exists = DMIExistsFilter(Seq("name", "tag"))
+        val prefix = DSLPrefixFilter(Seq("name", "tag"), PropertyType.Text.Property("abc"))
+        val exists = DSLExistsFilter(Seq("name", "tag"))
 
-        val or = DMIOrFilter(Seq(range, prefix, exists)).asJson
+        val or = DSLOrFilter(Seq(range, prefix, exists)).asJson
         or.toString() shouldBe """{
                                  |  "or" : [
                                  |    {
@@ -264,7 +264,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
                                  |}""".stripMargin
       }
       "work for not filter" in {
-        val containsAny = DMIContainsAnyFilter(
+        val containsAny = DSLContainsAnyFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Text.Property("abcdef"),
@@ -272,7 +272,7 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
           )
         )
 
-        val not = DMINotFilter(containsAny).asJson
+        val not = DSLNotFilter(containsAny).asJson
         not.toString() shouldBe """{
                                   |  "not" : {
                                   |    "containsAny" : {
@@ -293,8 +293,8 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
 
     "encode a mix filter" should {
       "work for complex case" in {
-        val equalInt = DMIEqualsFilter(Seq("name", "tag"), PropertyType.Bigint.Property(BigInt("123456789123456789123456789")))
-        val in = DMIInFilter(
+        val equalInt = DSLEqualsFilter(Seq("name", "tag"), PropertyType.Bigint.Property(BigInt("123456789123456789123456789")))
+        val in = DSLInFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Bigint.Property(BigInt("123456789123456789123456789")),
@@ -303,17 +303,17 @@ class DomainSpecificLanguageFilterSerializerTest extends AnyWordSpec with Matche
             PropertyType.Float32.Property(2.64f)
           )
         )
-        val containsAny = DMIContainsAnyFilter(
+        val containsAny = DSLContainsAnyFilter(
           Seq("name", "tag"),
           Seq(
             PropertyType.Text.Property("abcdef"),
             PropertyType.Float32.Property(2.64f)
           )
         )
-        val orEqual = DMIOrFilter(Seq(equalInt))
-        val orInContainsAny = DMIOrFilter(Seq(in, containsAny))
+        val orEqual = DSLOrFilter(Seq(equalInt))
+        val orInContainsAny = DSLOrFilter(Seq(in, containsAny))
 
-        val complex = DMIAndFilter(Seq(orEqual, orInContainsAny)).asJson
+        val complex = DSLAndFilter(Seq(orEqual, orInContainsAny)).asJson
         complex.toString() shouldBe """{
                                   |  "and" : [
                                   |    {

--- a/src/test/scala/com/cognite/sdk/scala/v1/NodesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/NodesTest.scala
@@ -4,7 +4,7 @@
 package com.cognite.sdk.scala.v1
 
 import cats.effect.unsafe.implicits.global
-import com.cognite.sdk.scala.common.{CdpApiException, RetryWhile}
+import com.cognite.sdk.scala.common.{CdpApiException, DSLAndFilter, DSLContainsAnyFilter, DSLEqualsFilter, DSLExistsFilter, DSLInFilter, DSLNotFilter, DSLOrFilter, DSLPrefixFilter, DSLRangeFilter, RetryWhile}
 import org.scalatest.{Assertion, BeforeAndAfterAll}
 
 import java.time.LocalDate
@@ -256,11 +256,11 @@ class NodesTest
   it should "work with AND filter" in initAndCleanUpDataForQuery { _ =>
     val inputQueryAnd = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIAndFilter(
+      DSLAndFilter(
         Seq(
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0002")),
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true)),
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_float"), PropertyType.Float32.Property(1.64f))
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0002")),
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true)),
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_float"), PropertyType.Float32.Property(1.64f))
         )
       )
     )
@@ -278,10 +278,10 @@ class NodesTest
 
     val inputQueryAnd2 = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIAndFilter(
+      DSLAndFilter(
         Seq(
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0001")),
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true))
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0001")),
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true))
         )
       )
     )
@@ -297,10 +297,10 @@ class NodesTest
   it should "work with OR filter" in initAndCleanUpDataForQuery { _ =>
     val inputQueryOr = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIOrFilter(
+      DSLOrFilter(
         Seq(
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0011")),
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true))
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0011")),
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true))
         )
       )
     )
@@ -319,8 +319,8 @@ class NodesTest
   it should "work with NOT filter" in initAndCleanUpDataForQuery { _ =>
     val inputQueryNot = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMINotFilter(
-        DMIInFilter(
+      DSLNotFilter(
+        DSLInFilter(
           Seq(space, dataModel.externalId, "prop_string"),
           Seq(PropertyType.Text.Property("EQ0002"), PropertyType.Text.Property("EQ0011"))
         )
@@ -341,7 +341,7 @@ class NodesTest
   it should "work with PREFIX filter" in initAndCleanUpDataForQuery { _ =>
     val inputQueryPrefix = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIPrefixFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ000"))
+      DSLPrefixFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ000"))
     )
     val outputQueryPrefix = blueFieldClient.nodes
       .query(inputQueryPrefix)
@@ -358,7 +358,7 @@ class NodesTest
   it should "work with RANGE filter" in initAndCleanUpDataForQuery { _ =>
     val inputQueryRange = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIRangeFilter(
+      DSLRangeFilter(
         Seq(space, dataModel.externalId, "prop_float"),
         gte = Some(PropertyType.Float32.Property(1.64f))
       )
@@ -377,7 +377,7 @@ class NodesTest
   it should "work with EXISTS filter" in initAndCleanUpDataForQuery { _ =>
     val inputQueryExists = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIExistsFilter(Seq(space, dataModel.externalId, "prop_bool"))
+      DSLExistsFilter(Seq(space, dataModel.externalId, "prop_bool"))
     )
     val outputQueryExists = blueFieldClient.nodes
       .query(inputQueryExists)
@@ -430,7 +430,7 @@ class NodesTest
   it should "work with CONTAINS ANY filter" in initAndCleanUpArrayDataForQuery { _ =>
     val inputQueryContainsAnyString = DataModelInstanceQuery(
       DataModelIdentifier(Some(space), dataModelArray.externalId),
-      DMIContainsAnyFilter(
+      DSLContainsAnyFilter(
         Seq(space, dataModelArray.externalId, "array_string"),
         Seq(
           PropertyType.Text.Property("E201"),
@@ -474,7 +474,7 @@ class NodesTest
   it should "work with CONTAINS ALL filter" in initAndCleanUpArrayDataForQuery { _ =>
     val inputQueryContainsAllString = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModelArray.externalId),
-      DMIContainsAnyFilter(
+      DSLContainsAnyFilter(
         Seq(space, dataModelArray.externalId, "array_string"),
         Seq(
           PropertyType.Text.Property("E201"),
@@ -520,7 +520,7 @@ class NodesTest
   ignore should "work with sort" in initAndCleanUpDataForQuery { _ =>
     val inputQueryExists = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIExistsFilter(Seq(dataModel.externalId, "prop_float")),
+      DSLExistsFilter(Seq(dataModel.externalId, "prop_float")),
       Some(Seq(dataModel.externalId, "col_float:desc"))
     )
     val outputQueryExists = blueFieldClient.nodes
@@ -539,10 +539,10 @@ class NodesTest
   it should "work with limit" in initAndCleanUpDataForQuery { _ =>
     val inputQueryOr = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIOrFilter(
+      DSLOrFilter(
         Seq(
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0011")),
-          DMIEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true))
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ0011")),
+          DSLEqualsFilter(Seq(space, dataModel.externalId, "prop_bool"), PropertyType.Boolean.Property(true))
         )
       ),
       None,
@@ -567,7 +567,7 @@ class NodesTest
   it should "work with cursor and stream" in initAndCleanUpDataForQuery { _ =>
     val inputQueryPrefix = DataModelInstanceQuery(
       DataModelIdentifier(Some(space),dataModel.externalId),
-      DMIPrefixFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ00"))
+      DSLPrefixFilter(Seq(space, dataModel.externalId, "prop_string"), PropertyType.Text.Property("EQ00"))
     )
 
     def checkOutputProp(output: Seq[PropertyMap]): Assertion = {


### PR DESCRIPTION
Move DomainSpecificLanguageFilter to a separate file
Also renaming `DMI...Filter` to `DSL...Filter`|
For now `nodes` and `edges` filter will use it, but with a bit more of refactor, it can be used for other resources like `events` filter as well