### PR TITLE
Fix flaky tests on requested token count

### DIFF
--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
@@ -157,7 +157,7 @@ class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionV
 
     retryWithExpectedResult[(Int,Int,Int)](
       io.unsafeRunTimed(10.seconds).value,
-      r => r shouldBe ((0, 1, 2)),
+      r => r shouldBe ((0, 1, 2))
     )
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
@@ -142,6 +142,7 @@ class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionV
     )
 
     val io = for {
+      _ <- numTokenRequests.update(_ => 0)
       authProvider <- OAuth2.ClientCredentialsProvider[IO](credentials,
         refreshSecondsBeforeExpiration = 2,
         Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
-class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionValues {
+class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionValues with RetryWhile {
   val tenant: String = sys.env("TEST_AAD_TENANT")
   val clientId: String = sys.env("TEST_CLIENT_ID")
   val clientSecret: String = sys.env("TEST_CLIENT_SECRET")
@@ -146,15 +146,18 @@ class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionV
         refreshSecondsBeforeExpiration = 2,
         Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
-      _ <- numTokenRequests.get.map(_ shouldBe 0)  // original token is still valid
+      noNewToken <- numTokenRequests.get  // original token is still valid
       _ <- IO.sleep(4.seconds)
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
-      _ <- numTokenRequests.get.map(_ shouldBe 1) // original token is expired
+      oneRequestedToken <- numTokenRequests.get // original token is expired
       _ <- IO.sleep(4.seconds)
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
-      _ <- numTokenRequests.get.map(_ shouldBe 2) // first renew token is expired
-    } yield ()
+      twoRequestedToken <- numTokenRequests.get // first renew token is expired
+    } yield (noNewToken, oneRequestedToken, twoRequestedToken)
 
-    io.unsafeRunTimed(10.seconds).value
+    retryWithExpectedResult[(Int,Int,Int)](
+      io.unsafeRunTimed(10.seconds).value,
+      r => r shouldBe ((0, 1, 2)),
+    )
   }
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
@@ -113,6 +113,7 @@ class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues with
         }
 
     val io = for {
+      _ <- numTokenRequests.update(_ => 0)
       authProvider <- OAuth2.SessionProvider[IO](
         session,
         refreshSecondsBeforeExpiration = 2,

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
@@ -21,7 +21,7 @@ import scala.collection.immutable.Seq
 import scala.concurrent.duration._
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Var"))
-class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues {
+class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues with RetryWhile {
 
   it should "not refresh tokens if original token is still valid" in {
     import sttp.client3.impl.cats.implicits._
@@ -119,16 +119,19 @@ class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues {
         Some(IO("kubernetesServiceToken")),
         Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
-      _ <- numTokenRequests.get.map(_ shouldBe 0)  // original token is still valid
+      noNewToken <- numTokenRequests.get  // original token is still valid
       _ <- IO.sleep(4.seconds)
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
-      _ <- numTokenRequests.get.map(_ shouldBe 1) // original token is expired
+      oneRequestedToken <- numTokenRequests.get // original token is expired
       _ <- IO.sleep(4.seconds)
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
-      _ <- numTokenRequests.get.map(_ shouldBe 2) // first renew token is expired
-    } yield ()
+      twoRequestedToken <- numTokenRequests.get // first renew token is expired
+    } yield (noNewToken, oneRequestedToken, twoRequestedToken)
 
-    io.unsafeRunTimed(10.seconds).value
+    retryWithExpectedResult[(Int,Int,Int)](
+      io.unsafeRunTimed(10.seconds).value,
+      r => r shouldBe ((0, 1, 2)),
+    )
   }
 
   it should "throw a CdpApiException error when failing to refresh the session" in {

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
@@ -130,7 +130,7 @@ class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues with
 
     retryWithExpectedResult[(Int,Int,Int)](
       io.unsafeRunTimed(10.seconds).value,
-      r => r shouldBe ((0, 1, 2)),
+      r => r shouldBe ((0, 1, 2))
     )
   }
 


### PR DESCRIPTION
Can't reproduce in local, and CI failed from time to time with these 2 tests, so adding retry on it to fix the issue