### PR TITLE
Abstract SlimNodeOrEdge types

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/SlimNodeOrEdge.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/SlimNodeOrEdge.scala
@@ -8,7 +8,11 @@ import io.circe.generic.semiauto.deriveDecoder
 import java.time.Instant
 
 sealed abstract class SlimNodeOrEdge extends Product with Serializable {
+  val space: String
+  val externalId: String
   val `type`: InstanceType
+  val createdTime: Option[Instant]
+  val lastUpdatedTime: Option[Instant]
 }
 
 object SlimNodeOrEdge {


### PR DESCRIPTION
This will help to remove some boilabplate

```
List[SlimNodeOrEdge]().map {
        case n: SlimNodeOrEdge.SlimNodeDefinition => n.externalId
        case n: SlimNodeOrEdge.SlimEdgeDefinition => n.externalId
      }
```