### PR TITLE
Add support for timeseries property

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/dataModelProperties.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataModelProperties.scala
@@ -74,7 +74,8 @@ object PropertyType {
     Date,
     Geometry,
     Geography,
-    DirectRelation
+    DirectRelation,
+    TimeSeries
   ) ++
     Array.values
 
@@ -99,6 +100,7 @@ object PropertyType {
   case object Geometry extends PrimitivePropertyType[String]
   case object Geography extends PrimitivePropertyType[String]
   case object DirectRelation extends PrimitivePropertyType[Seq[String]]
+  case object TimeSeries extends PrimitivePropertyType[String]
 
   object Array {
     val values: Seq[PropertyType[_]] = Seq[PropertyType[_]](

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/common/properties/PropertyDefinition.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/common/properties/PropertyDefinition.scala
@@ -134,6 +134,8 @@ object PropertyDefinition {
           Some(PropertyDefaultValue.Object(json))
         case _: PropertyType.DirectNodeRelationProperty =>
           Some(PropertyDefaultValue.Object(json))
+        case _: PropertyType.TimeSeriesProperty =>
+          json.asString.map(PropertyDefaultValue.String.apply)
         case _ => None
       }
     }

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/common/properties/PropertyType.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/common/properties/PropertyType.scala
@@ -43,12 +43,25 @@ object PropertyType {
     val Type = "direct"
   }
 
+  final case class TimeSeriesProperty() extends PropertyType {
+    val `type`: String = TimeSeriesProperty.Type
+
+    override def list: Option[Boolean] = None
+  }
+
+  object TimeSeriesProperty {
+    val Type = "timeseries"
+  }
+
   import com.cognite.sdk.scala.v1.fdm.containers.ContainerReference._
 
   implicit val propertyTypeTextEncoder: Encoder[TextProperty] =
     Encoder.forProduct3("list", "collation", "type")((t: TextProperty) =>
       (t.list, t.collation, t.`type`)
     )
+
+  implicit val propertyTimeSeriesEncoder: Encoder[TimeSeriesProperty] =
+    Encoder.forProduct1("type")((t: TimeSeriesProperty) => t.`type`)
 
   implicit val primitivePropertyEncoder: Encoder[PrimitiveProperty] =
     deriveEncoder[PrimitiveProperty]
@@ -62,6 +75,7 @@ object PropertyType {
     case t: TextProperty => t.asJson
     case p: PrimitiveProperty => p.asJson
     case d: DirectNodeRelationProperty => d.asJson
+    case ts: TimeSeriesProperty => ts.asJson
   }
 
   implicit val primitivePropertyDecoder: Decoder[PrimitiveProperty] =
@@ -69,6 +83,9 @@ object PropertyType {
 
   implicit val textPropertyDecoder: Decoder[TextProperty] =
     deriveDecoder[TextProperty]
+
+  implicit val timeSeriesPropertyDecoder: Decoder[TimeSeriesProperty] =
+    deriveDecoder[TimeSeriesProperty]
 
   implicit val directNodeRelationPropertyDecoder: Decoder[DirectNodeRelationProperty] =
     deriveDecoder[DirectNodeRelationProperty]
@@ -83,25 +100,30 @@ object PropertyType {
           } yield PrimitiveProperty(ppt, list)
       }
 
-      val textPropertyOrDirectNodeRelationProperty = c.downField("type").as[String] match {
-        case Left(err) => Left[DecodingFailure, PropertyType](err)
-        case Right(typeVal) if typeVal === TextProperty.Type =>
-          for {
-            list <- c.downField("list").as[Option[Boolean]]
-            collation <- c.downField("collation").as[Option[String]]
-          } yield TextProperty(list, collation)
-        case Right(typeVal) if typeVal === DirectNodeRelationProperty.Type =>
-          for {
-            containerRef <- c.downField("container").as[Option[ContainerReference]]
-            source <- c.downField("source").as[Option[ViewReference]]
-          } yield DirectNodeRelationProperty(containerRef, source)
-        case Right(typeVal) =>
-          Left[DecodingFailure, PropertyType](
-            DecodingFailure(s"Unknown container property type: '$typeVal'", c.history)
-          )
-      }
+      val textPropertyOrDirectNodeRelationPropertyOrTimeSeriesProperty =
+        c.downField("type").as[String] match {
+          case Left(err) => Left[DecodingFailure, PropertyType](err)
+          case Right(typeVal) if typeVal === TextProperty.Type =>
+            for {
+              list <- c.downField("list").as[Option[Boolean]]
+              collation <- c.downField("collation").as[Option[String]]
+            } yield TextProperty(list, collation)
+          case Right(typeVal) if typeVal === DirectNodeRelationProperty.Type =>
+            for {
+              containerRef <- c.downField("container").as[Option[ContainerReference]]
+              source <- c.downField("source").as[Option[ViewReference]]
+            } yield DirectNodeRelationProperty(containerRef, source)
+          case Right(typeVal) if typeVal == TimeSeriesProperty.Type =>
+            for { _ <- c.downField("type").as[Option[String]] } yield TimeSeriesProperty()
+          case Right(typeVal) =>
+            Left[DecodingFailure, PropertyType](
+              DecodingFailure(s"Unknown container property type: '$typeVal'", c.history)
+            )
+        }
 
-      Seq(primitiveProperty, textPropertyOrDirectNodeRelationProperty).find(_.isRight) match {
+      Seq(primitiveProperty, textPropertyOrDirectNodeRelationPropertyOrTimeSeriesProperty).find(
+        _.isRight
+      ) match {
         case Some(value) => value
         case None => Left(DecodingFailure(s"Unknown Property Type :${c.value.noSpaces}", c.history))
       }

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceDefinition.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceDefinition.scala
@@ -339,6 +339,10 @@ object InstanceDefinition {
         Decoder[Json]
           .decodeJson(propValue)
           .map(InstancePropertyValue.Object.apply)
+      case PropertyType.TimeSeriesProperty() =>
+        Decoder[String]
+          .decodeJson(propValue)
+          .map(InstancePropertyValue.String.apply)
       case _ =>
         Left[DecodingFailure, InstancePropertyValue](
           DecodingFailure(

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -1,7 +1,7 @@
 package com.cognite.sdk.scala.v1.fdm
 
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyDefinition.{ContainerPropertyDefinition, CorePropertyDefinition, ViewCorePropertyDefinition}
-import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyType.{DirectNodeRelationProperty, PrimitiveProperty, TextProperty}
+import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyType.{DirectNodeRelationProperty, PrimitiveProperty, TextProperty, TimeSeriesProperty}
 import com.cognite.sdk.scala.v1.fdm.common.properties.{PrimitivePropType, PropertyDefaultValue, PropertyType}
 import com.cognite.sdk.scala.v1.fdm.common.sources.SourceReference
 import com.cognite.sdk.scala.v1.fdm.common.{DirectRelationReference, Usage}
@@ -40,7 +40,8 @@ object Utils {
     PrimitiveProperty(`type` = PrimitivePropType.Json, list = Some(true)),
     DirectNodeRelationProperty(
       container = Some(ContainerReference(space = SpaceExternalId, externalId = DirectNodeRelationContainerExtId)),
-      source = None)
+      source = None),
+    TimeSeriesProperty()
   )
 
   val AllPropertyDefaultValues: List[PropertyDefaultValue] = List(
@@ -424,6 +425,7 @@ object Utils {
             )
           )
         )
+      case PropertyType.TimeSeriesProperty() => InstancePropertyValue.String(s"${propName}-reference")
       case other => throw new IllegalArgumentException(s"Unknown value :${other.toString}")
     }
   // scalastyle:on cyclomatic.complexity
@@ -479,6 +481,7 @@ object Utils {
             )
           )
         case _: DirectNodeRelationProperty => None
+        case _: TimeSeriesProperty => Some(PropertyDefaultValue.String("defaultTimeSeriesExternalIdValue"))
       }
     } else {
       None

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/containers/ContainersTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/containers/ContainersTest.scala
@@ -101,7 +101,8 @@ class ContainersTest extends CommonDataModelTestHelper {
       PropertyType.DirectNodeRelationProperty(Some(ContainerReference(space, "ext-id-1")), Some(ViewReference(space, "ext-id-1", "v1"))),
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Int32, list = None),
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Int64, list = Some(true)),
-      PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Date, list = Some(false))
+      PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Date, list = Some(false)),
+      PropertyType.TimeSeriesProperty()
     )
 
     val afterEncodedAndDecoded = values

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancePropertySerDeTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancePropertySerDeTest.scala
@@ -180,6 +180,16 @@ class InstancePropertySerDeTest extends AnyWordSpec with Matchers {
            |            "list": true,
            |            "collation": "ucs_basic"
            |          }
+           |        },
+           |        "property-identifier43": {
+           |          "nullable": true,
+           |          "autoIncrement": false,
+           |          "defaultValue": "timeseries-43",
+           |          "description": "property-identifier43",
+           |          "name": "property-identifier43",
+           |          "type": {
+           |            "type": "timeseries"
+           |          }
            |        }
            |      }
            |    }
@@ -307,6 +317,14 @@ class InstancePropertySerDeTest extends AnyWordSpec with Matchers {
                   Some("property-identifier42"),
                   Some("property-identifier42"),
                   PropertyType.TextProperty(Some(true), Some("ucs_basic"))
+                ),
+                "property-identifier43" -> TypePropertyDefinition(
+                  Some(true),
+                  Some(false),
+                  Some(PropertyDefaultValue.String("timeseries-43")),
+                  Some("property-identifier43"),
+                  Some("property-identifier43"),
+                  PropertyType.TimeSeriesProperty()
                 )
               )
             )

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/views/ViewsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/views/ViewsTest.scala
@@ -44,13 +44,22 @@ class ViewsTest extends CommonDataModelTestHelper with RetryWhile with BeforeAnd
     `type` = PropertyType.TextProperty()
   )
 
+  private val containerTimeSeriesProperty = ContainerPropertyDefinition(
+    defaultValue = Some(PropertyDefaultValue.String("flux-capacitor-levels")),
+    description = Some("defaultFlux1"),
+    name = Some("DeLorean flux capacitor levels"),
+    `type` = PropertyType.TimeSeriesProperty()
+  )
+
   private val containerPrimitive = ContainerCreateDefinition(
     space = spaceName,
     externalId = containerPrimitiveExternalId,
     name = Some(containerNamePrim),
     description = Some("this is a container of primitive types"),
     usedFor = Some(Usage.All),
-    properties = Map("prop_int32" -> containerPropertyInt, "prop_text" -> containerPropertyText),
+    properties = Map("prop_int32" -> containerPropertyInt,
+      "prop_text" -> containerPropertyText,
+      "prop_timeseries" -> containerTimeSeriesProperty),
     constraints = None,
     indexes = None
   )
@@ -101,7 +110,8 @@ class ViewsTest extends CommonDataModelTestHelper with RetryWhile with BeforeAnd
     val containerReference = ContainerReference(spaceName, containerPrimitiveExternalId)
     val properties = Map(
       "prop_int32" -> ViewPropertyCreateDefinition.CreateViewProperty(container = containerReference, containerPropertyIdentifier = "prop_int32"),
-      "prop_text" -> ViewPropertyCreateDefinition.CreateViewProperty(container = containerReference, containerPropertyIdentifier = "prop_text")
+      "prop_text" -> ViewPropertyCreateDefinition.CreateViewProperty(container = containerReference, containerPropertyIdentifier = "prop_text"),
+      "prop_timeseries" -> ViewPropertyCreateDefinition.CreateViewProperty(container = containerReference, containerPropertyIdentifier = "prop_timeseries")
     )
     val viewToCreate = ViewCreateDefinition(
       space = spaceName,
@@ -139,6 +149,14 @@ class ViewsTest extends CommonDataModelTestHelper with RetryWhile with BeforeAnd
           autoIncrement = Some(false),
           defaultValue = None,
           `type` = PropertyType.TextProperty(),
+          container = Some(containerReference),
+          containerPropertyIdentifier = None
+        ),
+        "prop_timeseries" -> ViewCorePropertyDefinition(
+          nullable = Some(true),
+          autoIncrement = Some(false),
+          defaultValue = Some(PropertyDefaultValue.String("flux-capacitor-levels")),
+          `type` = PropertyType.TimeSeriesProperty(),
           container = Some(containerReference),
           containerPropertyIdentifier = None
         )


### PR DESCRIPTION
This adds support for the primitive timeseries type, that is meant to hold an external-id for a time series existing in the time series resource type.