### PR TITLE
Fix version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,15 +18,13 @@ lazy val gpgPass = Option(System.getenv("GPG_KEY_PASSWORD"))
 
 ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix" % "0.1.5"
 
-lazy val patchVersion = scala.io.Source.fromFile("patch_version.txt").mkString.trim
-
 lazy val commonSettings = Seq(
   name := "cognite-sdk-scala",
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.5." + patchVersion,
-  isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
+  version := "2.5.11-SNAPSHOT",
+  isSnapshot := true,
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision,

--- a/patch_version.txt
+++ b/patch_version.txt
@@ -1,1 +1,0 @@
-11-SNAPSHOT


### PR DESCRIPTION
With `patch-version` it published `2.5.698`
https://github.com/cognitedata/cognite-sdk-scala/actions/runs/4697274399/jobs/8328322233
for PR https://github.com/cognitedata/cognite-sdk-scala/pull/611

Switching to the old version since this patch-version is not really necessary
