### PR TITLE
Remove TEST_API_KEY references from code&readme

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -125,7 +125,6 @@ jobs:
 
     - name: Run tests
       env:
-        TEST_API_KEY: ${{ secrets.playgroundApiKey }}
         TEST_AAD_TENANT: "b86328db-09aa-4f0e-9a03-0136f604d20a"
         TEST_CLIENT_ID: ${{ secrets.BLUEFIELD_CLIENT_ID }}
         TEST_CLIENT_SECRET: ${{ secrets.BLUEFIELD_CLIENT_SECRET }}

--- a/README.md
+++ b/README.md
@@ -210,5 +210,3 @@ TEST_AAD_TENANT="a valid azure ad tenant id"
 TEST_CLIENT_ID="the id of a valid client credential, belonging to the given tenant, and with access to the playground project"
 TEST_CLIENT_SECRET="a valid client secret for the given client id"
 ```
-
-Some tests for API Keys features are still in place, to run these tests the aditional environment variable `TEST_API_KEY` is needed, this should contain a valid API key for the playground project.


### PR DESCRIPTION
Since 9912c578e2e6d3eb8a7607645c24e416ffa429f2
api keys are no longer used, and they are also no longer
accepted by the CDF API.
