### PR TITLE
CDF-18449: add tracing support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,6 +13,7 @@ val sttpVersion = "3.5.2"
 val circeVersion = "0.14.5"
 val catsEffectVersion = "3.3.14"
 val fs2Version = "3.3.0"
+val natchezVersion = "0.3.1"
 
 lazy val gpgPass = Option(System.getenv("GPG_KEY_PASSWORD"))
 
@@ -25,7 +26,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.6." + patchVersion,
+  version := "2.7." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,
@@ -106,7 +107,8 @@ lazy val core = (project in file("."))
       "org.typelevel" %% "cats-effect-testkit" % catsEffectVersion % Test,
       "co.fs2" %% "fs2-core" % fs2Version,
       "co.fs2" %% "fs2-io" % fs2Version,
-      "com.google.protobuf" % "protobuf-java" % "3.21.4"
+      "com.google.protobuf" % "protobuf-java" % "3.21.4",
+      "org.tpolecat" %% "natchez-core" % natchezVersion
     ) ++ scalaTestDeps ++ sttpDeps ++ circeDeps(CrossVersion.partialVersion(scalaVersion.value)),
     scalacOptions ++= (CrossVersion.partialVersion(scalaVersion.value) match {
       case Some((2, minor)) if minor == 13 =>

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -18,12 +18,43 @@ import io.circe.generic.semiauto.deriveDecoder
 import sttp.capabilities.Effect
 import sttp.client3._
 import sttp.client3.circe.asJsonEither
-import sttp.model.{StatusCode, Uri}
+import sttp.model.{Header, StatusCode, Uri}
 import sttp.monad.MonadError
 
 import java.net.{InetAddress, UnknownHostException}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
+import natchez.Trace
+
+class TraceSttpBackend[F[_]: Trace, +P](delegate: SttpBackend[F, P]) extends SttpBackend[F, P] {
+
+  def sendImpl[T, R >: P with Effect[F]](
+      request: Request[T, R]
+  )(implicit monad: MonadError[F]): F[Response[T]] =
+    Trace[F].span("sttp-client-request") {
+      import sttp.monad.syntax._
+      for {
+        knl <- Trace[F].kernel
+        _ <- Trace[F].put(
+          "client.http.uri" -> request.uri.toString(),
+          "client.http.method" -> request.method.toString
+        )
+        response <- delegate.send(
+          request.headers(
+            knl.toHeaders.map { case (k, v) => Header(k.toString, v) }.toSeq ++
+              request.headers: _*
+          )
+        ) // prioritize request headers over kernel ones)
+        _ <- Trace[F].put("client.http.status_code" -> response.code.toString())
+      } yield response
+    }
+  override def send[T, R >: P with Effect[F]](request: Request[T, R]): F[Response[T]] =
+    sendImpl(request)(responseMonad)
+
+  override def close(): F[Unit] = delegate.close()
+
+  override def responseMonad: MonadError[F] = delegate.responseMonad
+}
 
 class AuthSttpBackend[F[_], +P](delegate: SttpBackend[F, P], authProvider: AuthProvider[F])
     extends SttpBackend[F, P] {
@@ -37,7 +68,7 @@ class AuthSttpBackend[F[_], +P](delegate: SttpBackend[F, P], authProvider: AuthP
   override def responseMonad: MonadError[F] = delegate.responseMonad
 }
 
-final case class RequestSession[F[_]: Monad](
+final case class RequestSession[F[_]: Monad: Trace](
     applicationName: String,
     baseUrl: Uri,
     baseSttpBackend: SttpBackend[F, _],
@@ -45,7 +76,8 @@ final case class RequestSession[F[_]: Monad](
     clientTag: Option[String] = None,
     cdfVersion: Option[String] = None
 ) {
-  val sttpBackend: SttpBackend[F, _] = new AuthSttpBackend(baseSttpBackend, auth)
+  val sttpBackend: SttpBackend[F, _] =
+    new AuthSttpBackend(new TraceSttpBackend(baseSttpBackend), auth)
 
   def send[R](
       r: RequestT[Empty, Either[String, String], Any] => RequestT[Id, R, Any]
@@ -130,7 +162,7 @@ final case class RequestSession[F[_]: Monad](
 }
 
 // scalastyle:off parameter.number
-class GenericClient[F[_]](
+class GenericClient[F[_]: Trace](
     applicationName: String,
     val projectName: String,
     baseUrl: String,
@@ -245,10 +277,13 @@ object GenericClient {
   val defaultBaseUrl: String = Option(System.getenv("COGNITE_BASE_URL"))
     .getOrElse("https://api.cognitedata.com")
 
-  def apply[F[_]: Monad](applicationName: String, projectName: String, baseUrl: String, auth: Auth)(
-      implicit sttpBackend: SttpBackend[F, Any]
-  ): GenericClient[F] =
-    new GenericClient(applicationName, projectName, baseUrl, auth)(implicitly, sttpBackend)
+  def apply[F[_]: Monad: Trace](
+      applicationName: String,
+      projectName: String,
+      baseUrl: String,
+      auth: Auth
+  )(implicit sttpBackend: SttpBackend[F, Any]): GenericClient[F] =
+    new GenericClient(applicationName, projectName, baseUrl, auth)
 
   def parseBaseUrlOrThrow(baseUrl: String): Uri =
     try {
@@ -277,7 +312,7 @@ object GenericClient {
         )
     }
 
-  def forAuth[F[_]: Monad](
+  def forAuth[F[_]: Monad: Trace](
       applicationName: String,
       projectName: String,
       auth: Auth,
@@ -296,7 +331,7 @@ object GenericClient {
       cdfVersion
     )
 
-  def forAuthProvider[F[_]: Monad](
+  def forAuthProvider[F[_]: Monad: Trace](
       applicationName: String,
       projectName: String,
       authProvider: AuthProvider[F],
@@ -317,9 +352,6 @@ object GenericClient {
           apiVersion,
           clientTag,
           cdfVersion
-        )(
-          implicitly,
-          sttpBackend
         )
       )
     }
@@ -361,11 +393,17 @@ class Client(
     baseUrl: String =
       Option(System.getenv("COGNITE_BASE_URL")).getOrElse("https://api.cognitedata.com"),
     auth: Auth
-)(implicit sttpBackend: SttpBackend[Id, Any])
+)(implicit trace: Trace[Id], sttpBackend: SttpBackend[Id, Any])
     extends GenericClient[Id](applicationName, projectName, baseUrl, auth)
 
 object Client {
-  def apply(applicationName: String, projectName: String, baseUrl: String, auth: Auth)(
-      implicit sttpBackend: SttpBackend[Id, Any]
-  ): Client = new Client(applicationName, projectName, baseUrl, auth)(sttpBackend)
+  def apply(
+      applicationName: String,
+      projectName: String,
+      baseUrl: String,
+      auth: Auth
+  )(
+      implicit trace: Trace[Id],
+      sttpBackend: SttpBackend[Id, Any]
+  ): Client = new Client(applicationName, projectName, baseUrl, auth)
 }

--- a/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/FilterTest.scala
@@ -47,7 +47,7 @@ class FilterTest extends SdkTestSpec with OptionValues {
     lazy val dummyClient = Client("foo",
       projectName,
       "https://api.cognitedata.com",
-      auth)(requestHijacker)
+      auth)(implicitly, requestHijacker)
     val dummyRequestSession = dummyClient.requestSession
 
     val _ = Filter.filterWithCursor(

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
@@ -22,6 +22,7 @@ import scala.concurrent.duration._
 
 @SuppressWarnings(Array("org.wartremover.warts.Var", "org.wartremover.warts.NonUnitStatements"))
 class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionValues with RetryWhile {
+  import natchez.Trace.Implicits.noop
   val tenant: String = sys.env("TEST_AAD_TENANT")
   val clientId: String = sys.env("TEST_CLIENT_ID")
   val clientSecret: String = sys.env("TEST_CLIENT_SECRET")

--- a/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/ReadTest.scala
@@ -37,7 +37,7 @@ class ReadTest extends SdkTestSpec with OptionValues {
     lazy val dummyClient = Client("foo",
       projectName,
       "https://api.cognitedata.com",
-      auth)(requestHijacker)
+      auth)(implicitly, requestHijacker)
     val dummyRequestSession = dummyClient.requestSession
 
     Readable.readWithCursor(

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -60,7 +60,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         headers = req.headers
         Response.ok(tokenInspectResponse).copy(headers = req.headers)
       }
-    new GenericClient[Id]("scala-sdk-test", projectName, auth = auth, clientTag = Some("client-test"))(implicitly, saveHeadersStub)
+    new GenericClient[Id]("scala-sdk-test", projectName, auth = auth, clientTag = Some("client-test"))(implicitly, implicitly, saveHeadersStub)
       .token.inspect()
     headers should contain (Header("x-cdp-clienttag", "client-test"))
     headers should contain (Header("x-cdp-sdk", s"CogniteScalaSDK:${BuildInfo.version}"))
@@ -75,6 +75,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
       auth
     )(
       implicitly,
+      implicitly,
       new RetryingBackend[IO, Any](AsyncHttpClientCatsBackend[IO]().unsafeRunSync())
     ).token.inspect().unsafeRunSync().projects should not be empty
   }
@@ -86,6 +87,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
       baseUrl,
       auth
     )(
+      implicitly,
       implicitly,
       RateLimitingBackend[Any](AsyncHttpClientCatsBackend[IO]().unsafeRunSync(), 5)
     ).token.inspect().unsafeRunSync().projects should not be empty
@@ -104,6 +106,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
       auth
     )(
       implicitly,
+      implicitly,
       new BackpressureThrottleBackend[IO, Any](AsyncHttpClientCatsBackend[IO]().unsafeRunSync(), makeQueueOf1.unsafeRunSync(), 1.seconds)
     ).token.inspect().unsafeRunSync().projects should not be empty
   }
@@ -113,6 +116,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
     an[InvalidAuthentication] should be thrownBy GenericClient.forAuth[Id](
       "scala-sdk-test", "", auth)(
       implicitly,
+      implicitly,
       sttpBackend
     ).assets.list(Some(1)).compile.toList
   }
@@ -121,6 +125,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
     implicit val auth: Auth = BearerTokenAuth("invalid-key", project = Some("random-project"))
     noException should be thrownBy new GenericClient[Id](
       "scala-sdk-test", projectName, auth = auth)(
+      implicitly,
       implicitly,
       sttpBackend
     )
@@ -133,7 +138,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         projectName,
         "",
         auth
-      )(new LoggingSttpBackend[Id, Any](sttpBackend)).token.inspect()
+      )(implicitly, new LoggingSttpBackend[Id, Any](sttpBackend)).token.inspect()
     }
     assertThrows[UnknownHostException] {
       Client(
@@ -141,7 +146,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         projectName,
         "thisShouldThrowAnUnknownHostException:)",
         auth
-      )(sttpBackend).token.inspect()
+      )(implicitly, sttpBackend).token.inspect()
     }
   }
 
@@ -152,7 +157,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         projectName,
         "http://api.cognitedata.com",
         auth
-      )(sttpBackend).token.inspect()
+      )(implicitly, sttpBackend).token.inspect()
     }
   }
 
@@ -165,6 +170,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         auth
       )(
         implicitly,
+        implicitly,
         makeTestingBackend()
       ).threeDModels.list().compile.toList.unsafeRunSync()
     }
@@ -175,6 +181,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         baseUrl,
         auth
       )(
+      implicitly,
       implicitly,
       new RetryingBackend[IO, Any](
         makeTestingBackend(),
@@ -190,6 +197,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         auth
       )(
         implicitly,
+        implicitly,
         new RetryingBackend[IO, Any](
           makeTestingBackend(),
           maxRetries = 4,
@@ -204,7 +212,8 @@ class ClientTest extends SdkTestSpec with OptionValues {
       projectName,
       "https://www.cognite.com/nowhereatall",
       BearerTokenAuth("irrelevant", Some("randomproject"))
-    )(implicitly,
+    )(natchez.Trace.Implicits.noop,
+      implicitly,
       new RetryingBackend[F, Any](backend,
         maxRetries = maxRetries,
         initialRetryDelay = 1.millis,
@@ -234,6 +243,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
       BearerTokenAuth("irrelevant", Some("randomproject"))
 
     )(
+      implicitly,
       implicitly,
       new RetryingBackend[IO, Any](backendStub,
         initialRetryDelay = 1.millis,
@@ -313,6 +323,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
       BearerTokenAuth("irrelevant", Some("randomproject"))
     )(
       implicitly,
+      implicitly,
       new RetryingBackend[IO, Any](
         badRequestBackendStub,
         initialRetryDelay = 1.millis,
@@ -350,6 +361,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
       "https://www.cognite.com/nowhere-at-all",
       BearerTokenAuth("irrelevant", Some("randomproject"))
     )(
+      implicitly,
       implicitly,
       new RetryingBackend[IO, Any](
         badRequestBackendStub1,
@@ -395,6 +407,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
         baseUrl,
         auth
       )(
+        implicitly,
         implicitly,
         makeTestingBackend()
       ).threeDModels.list().compile.toList.unsafeRunSync()

--- a/src/test/scala/com/cognite/sdk/scala/v1/CommonDataModelTestHelper.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/CommonDataModelTestHelper.scala
@@ -12,6 +12,8 @@ import sttp.client3.asynchttpclient.cats.AsyncHttpClientCatsBackend
 
 import scala.concurrent.duration.DurationInt
 
+import natchez.Trace
+
 @SuppressWarnings(
   Array(
     "org.wartremover.warts.OptionPartial",
@@ -19,6 +21,7 @@ import scala.concurrent.duration.DurationInt
   )
 )
 trait CommonDataModelTestHelper extends AnyFlatSpec with Matchers {
+  implicit val trace: Trace[IO] = natchez.Trace.Implicits.noop
   val tenant: String = sys.env("TEST_AAD_TENANT")
   val clientId: String = sys.env("TEST_CLIENT_ID")
   val clientSecret: String = sys.env("TEST_CLIENT_SECRET")
@@ -47,6 +50,7 @@ trait CommonDataModelTestHelper extends AnyFlatSpec with Matchers {
     None,
     Some("alpha")
   )(
+    implicitly,
     implicitly,
     new RetryingBackend[IO, Any](implicitly)
   )

--- a/src/test/scala/com/cognite/sdk/scala/v1/SessionsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/SessionsTest.scala
@@ -39,7 +39,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionCreated)
+    )(implicitly, implicitly, responseForSessionCreated)
 
     val resCreate = client.sessions.createWithClientCredentialFlow(
       Items[SessionCreateWithCredential](
@@ -72,7 +72,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionCreated)
+    )(implicitly, implicitly, responseForSessionCreated)
 
     val resCreate = client.sessions.createWithTokenExchangeFlow(
       Items[SessionCreateWithToken](
@@ -112,7 +112,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionCreated)
+    )(implicitly, implicitly, responseForSessionCreated)
 
     val error = the[CdpApiException] thrownBy client.sessions.createWithClientCredentialFlow(
       Items[SessionCreateWithCredential](
@@ -152,7 +152,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionCreated)
+    )(implicitly, implicitly, responseForSessionCreated)
 
     val error = the[CdpApiException] thrownBy client.sessions.createWithClientCredentialFlow(
       Items[SessionCreateWithCredential](
@@ -195,7 +195,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionList)
+    )(implicitly, implicitly, responseForSessionList)
 
     val responseList = client.sessions.list()
     responseList.size shouldBe 2
@@ -233,7 +233,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionBound)
+    )(implicitly, implicitly, responseForSessionBound)
 
     val responseBind = client.sessions.bind(BindSessionRequest("nonce-value"))
     responseBind shouldBe expectedResponse
@@ -271,7 +271,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionBound)
+    )(implicitly, implicitly, responseForSessionBound)
 
     val error = the[CdpApiException] thrownBy client.sessions.bind(BindSessionRequest("expired-nonce"))
     error.message shouldBe "Nonce has expired"
@@ -308,7 +308,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionRefresh)
+    )(implicitly, implicitly, responseForSessionRefresh)
 
     val responseBind = client.sessions.refresh(RefreshSessionRequest(123, "sessionKey-value"))
     responseBind shouldBe expectedResponse
@@ -346,7 +346,7 @@ class SessionsTest extends SdkTestSpec with ReadBehaviours {
       applicationName = "CogniteScalaSDK-OAuth-Test",
       projectName = "session-testing",
       auth = BearerTokenAuth("bearer Token")
-    )(implicitly, responseForSessionRefresh)
+    )(implicitly, implicitly, responseForSessionRefresh)
 
     val error = the[CdpApiException] thrownBy client.sessions.refresh(RefreshSessionRequest(123, "invalid-sessionKey"))
     error.message shouldBe "Session not found"

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -16,7 +16,7 @@ import scala.util.Random
 
 object Utils {
   def shortRandom(): String = UUID.randomUUID().toString.substring(0, 8)
-  val SpaceExternalId: String = s"testSpaceScalaSdk1-${shortRandom()}"
+  val SpaceExternalId = s"testSpaceScalaSdk1-${shortRandom()}"
   val DirectNodeRelationContainerExtId = "sdkTestNodeContainerForDirectRelation6"
   val DirectNodeRelationViewExtId = "sdkTestNodeViewForDirectRelation6"
   val ViewVersion = "v1"

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -1,5 +1,6 @@
 package com.cognite.sdk.scala.v1.fdm
 
+import java.util.UUID
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyDefinition.{ContainerPropertyDefinition, CorePropertyDefinition, ViewCorePropertyDefinition}
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyType._
 import com.cognite.sdk.scala.v1.fdm.common.properties.{PrimitivePropType, PropertyDefaultValue, PropertyType}
@@ -14,7 +15,8 @@ import java.time.{LocalDate, LocalDateTime, ZoneId}
 import scala.util.Random
 
 object Utils {
-  val SpaceExternalId = "testSpaceScalaSdk1"
+  def shortRandom(): String = UUID.randomUUID().toString.substring(0, 8)
+  val SpaceExternalId = s"testSpaceScalaSdk1-${shortRandom()}"
   val DirectNodeRelationContainerExtId = "sdkTestNodeContainerForDirectRelation6"
   val DirectNodeRelationViewExtId = "sdkTestNodeViewForDirectRelation6"
   val ViewVersion = "v1"

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -16,7 +16,7 @@ import scala.util.Random
 
 object Utils {
   def shortRandom(): String = UUID.randomUUID().toString.substring(0, 8)
-  val SpaceExternalId = s"testSpaceScalaSdk1-${shortRandom()}"
+  val SpaceExternalId: String = s"testSpaceScalaSdk1-${shortRandom()}"
   val DirectNodeRelationContainerExtId = "sdkTestNodeContainerForDirectRelation6"
   val DirectNodeRelationViewExtId = "sdkTestNodeViewForDirectRelation6"
   val ViewVersion = "v1"

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -1,6 +1,5 @@
 package com.cognite.sdk.scala.v1.fdm
 
-import java.util.UUID
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyDefinition.{ContainerPropertyDefinition, CorePropertyDefinition, ViewCorePropertyDefinition}
 import com.cognite.sdk.scala.v1.fdm.common.properties.PropertyType._
 import com.cognite.sdk.scala.v1.fdm.common.properties.{PrimitivePropType, PropertyDefaultValue, PropertyType}
@@ -15,8 +14,7 @@ import java.time.{LocalDate, LocalDateTime, ZoneId}
 import scala.util.Random
 
 object Utils {
-  def shortRandom(): String = UUID.randomUUID().toString.substring(0, 8)
-  val SpaceExternalId = s"testSpaceScalaSdk1-${shortRandom()}"
+  val SpaceExternalId = "testSpaceScalaSdk1"
   val DirectNodeRelationContainerExtId = "sdkTestNodeContainerForDirectRelation6"
   val DirectNodeRelationViewExtId = "sdkTestNodeViewForDirectRelation6"
   val ViewVersion = "v1"

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -31,14 +31,14 @@ class InstancesTest extends CommonDataModelTestHelper {
 
   private val edgeNodeContainerExtId = "sdkTest10EdgeNodeContainer2"
   private val edgeContainerExtId = "sdkTest10EdgeContainer2"
-  private val nodeContainer1ExtId = "sdkTest10NodeContainer1"
-  private val nodeContainer2ExtId = "sdkTest10NodeContainer2"
+  private val nodeContainer1ExtId = "sdkTest10NodeContainer3"
+  private val nodeContainer2ExtId = "sdkTest10NodeContainer4"
   private val containerForDirectNodeRelationExtId = Utils.DirectNodeRelationContainerExtId
 
-  private val edgeNodeViewExtId = "sdkTest10EdgeNodeView"
-  private val edgeViewExtId = "sdkTest10EdgeView"
-  private val nodeView1ExtId = "sdkTest10NodeView1"
-  private val nodeView2ExtId = "sdkTest10NodeView2"
+  private val edgeNodeViewExtId = "sdkTest10EdgeNodeView2"
+  private val edgeViewExtId = "sdkTest10EdgeView3"
+  private val nodeView1ExtId = "sdkTest10NodeView4"
+  private val nodeView2ExtId = "sdkTest10NodeView5"
   private val viewForDirectNodeRelationExtId = Utils.DirectNodeRelationViewExtId
 
   private val viewVersion = Utils.ViewVersion

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -30,7 +30,7 @@ class InstancesTest extends CommonDataModelTestHelper {
   private val space = Utils.SpaceExternalId
 
   private val edgeNodeContainerExtId = "sdkTest10EdgeNodeContainer2"
-  private val edgeContainerExtId = "sdkTest10EdgeContainer"
+  private val edgeContainerExtId = "sdkTest10EdgeContainer2"
   private val nodeContainer1ExtId = "sdkTest10NodeContainer1"
   private val nodeContainer2ExtId = "sdkTest10NodeContainer2"
   private val containerForDirectNodeRelationExtId = Utils.DirectNodeRelationContainerExtId

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -29,7 +29,7 @@ import scala.concurrent.duration.DurationInt
 class InstancesTest extends CommonDataModelTestHelper {
   private val space = Utils.SpaceExternalId
 
-  private val edgeNodeContainerExtId = "sdkTest10EdgeNodeContainer"
+  private val edgeNodeContainerExtId = "sdkTest10EdgeNodeContainer2"
   private val edgeContainerExtId = "sdkTest10EdgeContainer"
   private val nodeContainer1ExtId = "sdkTest10NodeContainer1"
   private val nodeContainer2ExtId = "sdkTest10NodeContainer2"


### PR DESCRIPTION
- bump version to 2.7.x as changes on consumer side are required
- require `Trace` constraint on `F` for client https://typelevel.org/natchez/reference/trace.html can be satisfied with noop with `import natchez.Trace.Implicits.noop` if consumer has no tracing yet
- propagate trace through sttp calls, similar to natchez-http4s client code https://github.com/typelevel/natchez-http4s/blob/main/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala

also randomize InstancesTest space to make it less flaky and more isolated

[CDF-18449]


[CDF-18449]: https://cognitedata.atlassian.net/browse/CDF-18449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ