### PR TITLE
Reintroduce auto-generated version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,13 +18,15 @@ lazy val gpgPass = Option(System.getenv("GPG_KEY_PASSWORD"))
 
 ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix" % "0.1.5"
 
+lazy val patchVersion = scala.io.Source.fromFile("patch_version.txt").mkString.trim
+
 lazy val commonSettings = Seq(
   name := "cognite-sdk-scala",
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.5.14",
-  // isSnapshot := true,
+  version := "2.6." + patchVersion,
+  isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   crossScalaVersions := supportedScalaVersions,
   semanticdbEnabled := true,
   semanticdbVersion := scalafixSemanticdb.revision,

--- a/patch_version.txt
+++ b/patch_version.txt
@@ -1,0 +1,1 @@
+0-SNAPSHOT

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -41,9 +41,9 @@ object Utils {
     DirectNodeRelationProperty(
       container = Some(ContainerReference(space = SpaceExternalId, externalId = DirectNodeRelationContainerExtId)),
       source = None),
-    TimeSeriesReference(),
-    FileReference(),
-    SequenceReference()
+    TimeSeriesReference(list = Some(false)),
+    FileReference(list = Some(false)),
+    SequenceReference(list = Some(false))
 //TODO: Uncomment once the list types are released
 //    TimeSeriesReference(list = Some(true)),
 //    FileReference(list = Some(true)),

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/containers/ContainersTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/containers/ContainersTest.scala
@@ -102,14 +102,14 @@ class ContainersTest extends CommonDataModelTestHelper {
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Int32, list = None),
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Int64, list = Some(true)),
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Date, list = Some(false)),
-      PropertyType.TimeSeriesReference(list = None),
+      PropertyType.TimeSeriesReference(list = Some(false)),
 //TODO: Uncomment once the list types are released
 //      PropertyType.TimeSeriesReference(list = Some(true)),
 //      PropertyType.TimeSeriesReference(list = Some(false)),
-      PropertyType.FileReference(list = None),
+      PropertyType.FileReference(list = Some(false)),
 //      PropertyType.FileReference(list = Some(true)),
 //      PropertyType.FileReference(list = Some(false)),
-      PropertyType.SequenceReference(list = None)
+      PropertyType.SequenceReference(list = Some(false))
 //      PropertyType.SequenceReference(list = Some(true)),
 //      PropertyType.SequenceReference(list = Some(false))
     )

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/containers/ContainersTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/containers/ContainersTest.scala
@@ -102,14 +102,14 @@ class ContainersTest extends CommonDataModelTestHelper {
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Int32, list = None),
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Int64, list = Some(true)),
       PropertyType.PrimitiveProperty(`type` = PrimitivePropType.Date, list = Some(false)),
-      PropertyType.TimeSeriesReference(list = Some(false)),
+      PropertyType.TimeSeriesReference(list = None),
 //TODO: Uncomment once the list types are released
 //      PropertyType.TimeSeriesReference(list = Some(true)),
 //      PropertyType.TimeSeriesReference(list = Some(false)),
-      PropertyType.FileReference(list = Some(false)),
+      PropertyType.FileReference(list = None),
 //      PropertyType.FileReference(list = Some(true)),
 //      PropertyType.FileReference(list = Some(false)),
-      PropertyType.SequenceReference(list = Some(false))
+      PropertyType.SequenceReference(list = None)
 //      PropertyType.SequenceReference(list = Some(true)),
 //      PropertyType.SequenceReference(list = Some(false))
     )


### PR DESCRIPTION
`major.minor.` part can be bumped manually on significant changes,
last `.patch` part would be based on commit history depth and
will produce a new version for any commit automatically.

Bumps to `2.6.xxx`, `2.6` to indicate versioning change,
`xxx` will be over `700` but after that will go in small increments.

This reverts commit ae026bf11da765064d4667c16dc2266655692b4d.
