### PR TITLE
CDF-18756: automatically promote releases in sonatype

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -175,4 +175,4 @@ jobs:
         env:
           GPG_KEY_PASSWORD: ${{ secrets.gpg_key_password }}
         run: |
-          sbt -Dsbt.log.noformat=true -J-Xmx3G -J-XX:+UseG1GC +publishSigned
+          sbt -Dsbt.log.noformat=true -J-Xmx3G -J-XX:+UseG1GC +publishSigned +sonatypeRelease

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,6 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.10.3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.21")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.2")
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.4.1")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")


### PR DESCRIPTION
It seems that repo should be all set up to use sonatype plugin,
we only need to import plugin and run extra `sonatypeRelease` step.

https://www.scala-sbt.org/1.x/docs/Publishing.html
https://www.scala-sbt.org/1.x/docs/Using-Sonatype.html
https://github.com/xerial/sbt-sonatype

[CDF-18756]


[CDF-18756]: https://cognitedata.atlassian.net/browse/CDF-18756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ