### PR TITLE
InstanceCreate: Support explicit property deletion

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/instances.scala
@@ -9,7 +9,7 @@ import com.cognite.sdk.scala.v1.fdm.views.ViewReference
 
 final case class EdgeOrNodeData(
     source: SourceReference,
-    properties: Option[Map[String, InstancePropertyValue]]
+    properties: Option[Map[String, Option[InstancePropertyValue]]]
 )
 
 final case class InstanceCreate(

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
@@ -20,7 +20,9 @@ class Instances[F[_]](val requestSession: RequestSession[F])
 
   import Instances._
 
-  private implicit val nullDroppingPrinter: Printer = Printer.noSpaces.copy(dropNullValues = true)
+  // We need to keep null values. Specifying a null value for a property in InstanceCreate means
+  // that we delete the property. Dropping it means that we leave it alone.
+  private implicit val nullKeepingPrinter: Printer = Printer.noSpaces.copy(dropNullValues = false)
 
   override val baseUrl = uri"${requestSession.baseUrl}/models/instances"
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -407,7 +407,7 @@ object Utils {
   private def toInstanceData(ref: SourceReference, instancePropertyValues: Map[String, InstancePropertyValue]) =
     EdgeOrNodeData(
       source = ref,
-      properties = Some(instancePropertyValues)
+      properties = Some(instancePropertyValues.mapValues(v => Some(v)).toMap)
     )
 
   // scalastyle:off cyclomatic.complexity

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -151,7 +151,7 @@ class InstancesTest extends CommonDataModelTestHelper {
     instancePropertyMapEquals(writeDataToMap(nodeOrEdgeWriteData.head), readEdgesMapOfAll) shouldBe true
     instancePropertyMapEquals(writeDataToMap(nodeOrEdgeWriteData(1)), readNodesMapOfAll) shouldBe true
 
-    // Test deletion of properties: Make a new edit from node1WriteDta, but with 1 property set to None
+    // Test deletion of properties: Make a new edit from node1WriteData, but with 1 property set to None
     val nodeSource = node1WriteData.sources.get.head
     val nodeProps = nodeSource.properties.get
     val nodeKey = nodeProps.keys.find(k => !k.endsWith("NonNullable")).get
@@ -174,6 +174,7 @@ class InstancesTest extends CommonDataModelTestHelper {
     val emptyEditData = edgeWriteData.copy(sources = Some(Seq(edgeSource.copy(properties = Some(Map.empty)))))
     createInstance(Seq(emptyEditData))
     val readEditedEdge = fetchEdgeInstance(edgeView.toSourceReference, emptyEditData.externalId).unsafeRunSync()
+    // The read data equals the original creation data, since the above should be a noop
     instancePropertyMapEquals(writeDataToMap(edgeWriteData), readEditedEdge) shouldBe true
 
     val deletedInstances = deleteInstance(


### PR DESCRIPTION
When updating a node or edge with `InstanceCreate`, any properties in the property map that are explicitly set to `null` will be deleted from the instance. This is different from leaving the property out of the map, which does nothing to the property.

Support this in the sdk.