### PR TITLE
Don't duplicate request headers

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -41,8 +41,7 @@ class TraceSttpBackend[F[_]: Trace, +P](delegate: SttpBackend[F, P]) extends Stt
         )
         response <- delegate.send(
           request.headers(
-            knl.toHeaders.map { case (k, v) => Header(k.toString, v) }.toSeq ++
-              request.headers: _*
+            knl.toHeaders.map { case (k, v) => Header(k.toString, v) }.toSeq: _*
           )
         ) // prioritize request headers over kernel ones)
         _ <- Trace[F].put("client.http.status_code" -> response.code.toString())

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -43,7 +43,7 @@ class TraceSttpBackend[F[_]: Trace, +P](delegate: SttpBackend[F, P]) extends Stt
           request.headers(
             knl.toHeaders.map { case (k, v) => Header(k.toString, v) }.toSeq: _*
           )
-        ) // prioritize request headers over kernel ones)
+        )
         _ <- Trace[F].put("client.http.status_code" -> response.code.toString())
       } yield response
     }


### PR DESCRIPTION
originated from http4s client https://github.com/typelevel/natchez-http4s/blob/main/modules/http4s/src/main/scala/natchez/http4s/NatchezMiddleware.scala#L108 but there headers-setting has a bit different api