### PR TITLE
Simplify headers passing

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -100,6 +100,7 @@ final case class RequestSession[F[_]: Monad: Trace](
         ).flatMap(_.toList): _*
       )
     tags.foldLeft(baseRequest)((req, tag) => req.tag(tag._1, tag._2))
+  }
 
   def get[R, T](
       uri: Uri,

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -83,7 +83,7 @@ final case class RequestSession[F[_]: Monad: Trace](
   ): F[Response[R]] =
     r(emptyRequest.readTimeout(90.seconds)).send(sttpBackend)
 
-  private val sttpRequest = {
+  private val sttpRequest =
     basicRequest
       .followRedirects(false)
       .header("x-cdp-sdk", s"CogniteScalaSDK:${BuildInfo.version}")
@@ -95,7 +95,6 @@ final case class RequestSession[F[_]: Monad: Trace](
           cdfVersion.map(Header("cdf-version", _))
         ).flatMap(_.toList): _*
       )
-  }
 
   def get[R, T](
       uri: Uri,


### PR DESCRIPTION
No need to match on all optional fields combination, we
can also go straight via list optionals -> list of headers.
