### PR TITLE
rework initial auth token support

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala
@@ -157,8 +157,7 @@ object OAuth2 {
     def apply[F[_]](
         credentials: ClientCredentials,
         refreshSecondsBeforeExpiration: Long = 30,
-        maybeCacheToken: Option[F[Option[TokenState]]] =
-          None // can't use F.pure(None) here hence extra Option[] wrapper
+        maybeCacheToken: Option[TokenState] = None
     )(
         implicit F: Async[F],
         clock: Clock[F],
@@ -167,8 +166,7 @@ object OAuth2 {
       val authenticate: F[TokenState] =
         for {
           now <- clock.realTime.map(_.toSeconds)
-          maybeTokenInCache <- maybeCacheToken.getOrElse(F.pure(None))
-          newToken <- maybeTokenInCache match {
+          newToken <- maybeCacheToken match {
             case Some(originalToken)
                 if now < (originalToken.expiresAt - refreshSecondsBeforeExpiration) =>
               F.delay(originalToken)
@@ -186,8 +184,7 @@ object OAuth2 {
         session: Session,
         refreshSecondsBeforeExpiration: Long = 30,
         getToken: Option[F[String]] = None,
-        maybeCacheToken: Option[F[Option[TokenState]]] =
-          None // can't use F.pure(None) here hence extra Option[] wrapper
+        maybeCacheToken: Option[TokenState] = None
     )(
         implicit F: Async[F],
         clock: Clock[F],
@@ -196,8 +193,7 @@ object OAuth2 {
       val authenticate: F[TokenState] =
         for {
           now <- clock.realTime.map(_.toSeconds)
-          maybeTokenInCache <- maybeCacheToken.getOrElse(F.pure(None))
-          newToken <- maybeTokenInCache match {
+          newToken <- maybeCacheToken match {
             case Some(originalToken)
                 if now < (originalToken.expiresAt - refreshSecondsBeforeExpiration) =>
               F.delay(originalToken)

--- a/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala
@@ -157,7 +157,7 @@ object OAuth2 {
     def apply[F[_]](
         credentials: ClientCredentials,
         refreshSecondsBeforeExpiration: Long = 30,
-        maybeCacheToken: Option[TokenState] = None
+        initialToken: Option[TokenState] = None
     )(
         implicit F: Async[F],
         clock: Clock[F],
@@ -166,7 +166,7 @@ object OAuth2 {
       val authenticate: F[TokenState] =
         for {
           now <- clock.realTime.map(_.toSeconds)
-          newToken <- maybeCacheToken match {
+          newToken <- initialToken match {
             case Some(originalToken)
                 if now < (originalToken.expiresAt - refreshSecondsBeforeExpiration) =>
               F.delay(originalToken)
@@ -184,7 +184,7 @@ object OAuth2 {
         session: Session,
         refreshSecondsBeforeExpiration: Long = 30,
         getToken: Option[F[String]] = None,
-        maybeCacheToken: Option[TokenState] = None
+        initialToken: Option[TokenState] = None
     )(
         implicit F: Async[F],
         clock: Clock[F],
@@ -193,7 +193,7 @@ object OAuth2 {
       val authenticate: F[TokenState] =
         for {
           now <- clock.realTime.map(_.toSeconds)
-          newToken <- maybeCacheToken match {
+          newToken <- initialToken match {
             case Some(originalToken)
                 if now < (originalToken.expiresAt - refreshSecondsBeforeExpiration) =>
               F.delay(originalToken)

--- a/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/OAuth2.scala
@@ -27,7 +27,7 @@ object OAuth2 {
       cdfProjectName: String,
       audience: Option[String] = None
   ) {
-    def getAuth[F[_]](refreshSecondsBeforeExpiration: Long = 30)(
+    def getAuth[F[_]](
         implicit F: Async[F],
         clock: Clock[F],
         sttpBackend: SttpBackend[F, Any]
@@ -44,6 +44,7 @@ object OAuth2 {
         ) // Send empty audience when it is not provided
       )
       for {
+        acquiredLowerBound <- clock.realTime.map(_.toSeconds)
         response <- basicRequest
           .header("Accept", "application/json")
           .post(tokenUri)
@@ -70,8 +71,7 @@ object OAuth2 {
                 )
             }
         }
-        acquiredAt <- clock.realTime.map(_.toSeconds)
-        expiresAt = acquiredAt + payload.expires_in - refreshSecondsBeforeExpiration
+        expiresAt = acquiredLowerBound + payload.expires_in
       } yield TokenState(payload.access_token, expiresAt, cdfProjectName)
     }
   }
@@ -97,7 +97,6 @@ object OAuth2 {
     }
 
     def getAuth[F[_]](
-        refreshSecondsBeforeExpiration: Long = 30,
         getToken: Option[F[String]] = None
     )(
         implicit F: Async[F],
@@ -108,6 +107,7 @@ object OAuth2 {
       val uri = uri"${baseUrl}/api/v1/projects/${cdfProjectName}/sessions/token"
       for {
         kubernetesServiceToken <- getToken.getOrElse(getKubernetesJwt)
+        acquiredLowerBound <- clock.realTime.map(_.toSeconds)
         payload <- basicRequest
           .header("Accept", "application/json")
           .header("Authorization", s"Bearer ${kubernetesServiceToken}")
@@ -118,38 +118,42 @@ object OAuth2 {
           )
           .send(sttpBackend)
           .map(_.body)
-        acquiredAt <- clock.realTime.map(_.toSeconds)
-        expiresAt = acquiredAt + payload.expiresIn - refreshSecondsBeforeExpiration
+        expiresAt = acquiredLowerBound + payload.expiresIn
       } yield TokenState(payload.accessToken, expiresAt, cdfProjectName)
     }
   }
 
-  private def commonGetAuth[F[_]](cache: CachedResource[F, TokenState])(
+  private def commonGetAuth[F[_]](
+      cache: CachedResource[F, TokenState],
+      refreshSecondsBeforeExpiration: Long
+  )(
       implicit F: Monad[F],
       clock: Clock[F]
   ): F[Auth] =
     for {
       now <- clock.realTime.map(_.toSeconds)
-      _ <- cache.invalidateIfNeeded(_.expiresAt <= now)
+      _ <- cache.invalidateIfNeeded(_.expiresAt - refreshSecondsBeforeExpiration <= now)
       auth <- cache.run(state => F.pure(OidcTokenAuth(state.token, state.cdfProjectName)))
     } yield auth
 
   class ClientCredentialsProvider[F[_]] private (
-      cache: CachedResource[F, TokenState]
+      val cache: CachedResource[F, TokenState],
+      val refreshSecondsBeforeExpiration: Long
   )(
       implicit F: Monad[F],
       clock: Clock[F]
   ) extends AuthProvider[F]
       with Serializable {
-    def getAuth: F[Auth] = commonGetAuth(cache)
+    def getAuth: F[Auth] = commonGetAuth(cache, refreshSecondsBeforeExpiration)
   }
 
   class SessionProvider[F[_]] private (
-      cache: CachedResource[F, TokenState]
+      val cache: CachedResource[F, TokenState],
+      val refreshSecondsBeforeExpiration: Long
   )(implicit F: Monad[F], clock: Clock[F])
       extends AuthProvider[F]
       with Serializable {
-    def getAuth: F[Auth] = commonGetAuth(cache)
+    def getAuth: F[Auth] = commonGetAuth(cache, refreshSecondsBeforeExpiration)
   }
 
   // scalastyle:off method.length
@@ -160,22 +164,10 @@ object OAuth2 {
         initialToken: Option[TokenState] = None
     )(
         implicit F: Async[F],
-        clock: Clock[F],
         sttpBackend: SttpBackend[F, Any]
-    ): F[ClientCredentialsProvider[F]] = {
-      val authenticate: F[TokenState] =
-        for {
-          now <- clock.realTime.map(_.toSeconds)
-          newToken <- initialToken match {
-            case Some(originalToken)
-                if now < (originalToken.expiresAt - refreshSecondsBeforeExpiration) =>
-              F.delay(originalToken)
-            case _ =>
-              credentials.getAuth()
-          }
-        } yield newToken
-      ConcurrentCachedObject(authenticate).map(new ClientCredentialsProvider[F](_))
-    }
+    ): F[ClientCredentialsProvider[F]] =
+      ConcurrentCachedObject(credentials.getAuth, initialToken)
+        .map(new ClientCredentialsProvider[F](_, refreshSecondsBeforeExpiration))
   }
   // scalastyle:on method.length
 
@@ -187,22 +179,10 @@ object OAuth2 {
         initialToken: Option[TokenState] = None
     )(
         implicit F: Async[F],
-        clock: Clock[F],
         sttpBackend: SttpBackend[F, Any]
-    ): F[SessionProvider[F]] = {
-      val authenticate: F[TokenState] =
-        for {
-          now <- clock.realTime.map(_.toSeconds)
-          newToken <- initialToken match {
-            case Some(originalToken)
-                if now < (originalToken.expiresAt - refreshSecondsBeforeExpiration) =>
-              F.delay(originalToken)
-            case _ =>
-              session.getAuth(getToken = getToken)
-          }
-        } yield newToken
-      ConcurrentCachedObject(authenticate).map(new SessionProvider[F](_))
-    }
+    ): F[SessionProvider[F]] =
+      ConcurrentCachedObject(session.getAuth(getToken = getToken), initialToken)
+        .map(new SessionProvider[F](_, refreshSecondsBeforeExpiration))
   }
 
   private final case class ClientCredentialsResponse(access_token: String, expires_in: Long)

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2ClientCredentialsTest.scala
@@ -146,7 +146,7 @@ class OAuth2ClientCredentialsTest extends AnyFlatSpec with Matchers with OptionV
       _ <- numTokenRequests.update(_ => 0)
       authProvider <- OAuth2.ClientCredentialsProvider[IO](credentials,
         refreshSecondsBeforeExpiration = 2,
-        Some(IO.pure(Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))))
+        Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
       noNewToken <- numTokenRequests.get  // original token is still valid
       _ <- IO.sleep(4.seconds)

--- a/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/OAuth2SessionTest.scala
@@ -62,7 +62,7 @@ class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues with
         session,
         refreshSecondsBeforeExpiration = 1,
         Some(IO("kubernetesServiceToken")),
-        Some(IO.pure(Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 5, "irrelevant")))))
+        Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 5, "irrelevant")))
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
       _ <- numTokenRequests.get.map(_ shouldBe 0)
       _ <- IO.sleep(3.seconds)
@@ -118,7 +118,7 @@ class OAuth2SessionTest extends AnyFlatSpec with Matchers with OptionValues with
         session,
         refreshSecondsBeforeExpiration = 2,
         Some(IO("kubernetesServiceToken")),
-        Some(IO.pure(Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))))
+        Some(TokenState("firstToken", Clock[IO].realTime.map(_.toSeconds).unsafeRunSync() + 4, "irrelevant")))
       _ <- List.fill(5)(authProvider.getAuth).parUnorderedSequence
       noNewToken <- numTokenRequests.get  // original token is still valid
       _ <- IO.sleep(4.seconds)

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -31,16 +31,16 @@ import scala.concurrent.duration.DurationInt
 class InstancesTest extends CommonDataModelTestHelper {
   private val space = Utils.SpaceExternalId
 
-  private val edgeNodeContainerExtId = "sdkTest11EdgeNodeContainer2"
-  private val edgeContainerExtId = "sdkTest11EdgeContainer2"
-  private val nodeContainer1ExtId = "sdkTest11NodeContainer3"
-  private val nodeContainer2ExtId = "sdkTest11NodeContainer4"
+  private val edgeNodeContainerExtId = "sdkTest12EdgeNodeContainer2"
+  private val edgeContainerExtId = "sdkTest12EdgeContainer2"
+  private val nodeContainer1ExtId = "sdkTest12NodeContainer3"
+  private val nodeContainer2ExtId = "sdkTest12NodeContainer4"
   private val containerForDirectNodeRelationExtId = Utils.DirectNodeRelationContainerExtId
 
-  private val edgeNodeViewExtId = "sdkTest11EdgeNodeView2"
-  private val edgeViewExtId = "sdkTest11EdgeView3"
-  private val nodeView1ExtId = "sdkTest11NodeView4"
-  private val nodeView2ExtId = "sdkTest11NodeView5"
+  private val edgeNodeViewExtId = "sdkTest12EdgeNodeView2"
+  private val edgeViewExtId = "sdkTest12EdgeView3"
+  private val nodeView1ExtId = "sdkTest12NodeView4"
+  private val nodeView2ExtId = "sdkTest12NodeView5"
   private val viewForDirectNodeRelationExtId = Utils.DirectNodeRelationViewExtId
 
   private val viewVersion = Utils.ViewVersion


### PR DESCRIPTION
- Revert "Wrap maybeCacheToken parameter into effect (#638)"
- rename "cache" -> "initial" token to better reflect what it does
- add support for initial token in CachedResource. Without it consumers had to put initial token bypass into each call of token getting callback
- shift around token expiration computations:
  - add `expires_in` to a time just before making a request, it's a server response so comes with some delay, better to be more cautious and assume it was issued and received instantaneously and expire-refresh a little sooner than needed than to think it's not expired but it actually is due to getting-token roundtrip
  - keep expires_at value pure, apply refresh safety margin explicitly when checking if refresh is needed