### PR TITLE
Parse capabilities from token/inspect

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 import wartremover.Wart
-import sbt.project
+import sbt.{Test, project}
 
 //val scala3 = "3.2.0"
 val scala213 = "2.13.8"
@@ -164,6 +164,9 @@ def circeDeps(scalaVersion: Option[(Long, Long)]): Seq[ModuleID] =
       .exclude("org.typelevel", "cats-core_2.12")
       .exclude("org.typelevel", "cats-core_2.13"),
     ("io.circe" %% "circe-parser" % circeVersion)
+      .exclude("org.typelevel", "cats-core_2.12")
+      .exclude("org.typelevel", "cats-core_2.13"),
+    ("io.circe" %% "circe-literal" % circeVersion % Test)
       .exclude("org.typelevel", "cats-core_2.12")
       .exclude("org.typelevel", "cats-core_2.13")
   )

--- a/src/main/scala/com/cognite/sdk/scala/common/token.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/token.scala
@@ -3,23 +3,82 @@
 
 package com.cognite.sdk.scala.common
 
-import com.cognite.sdk.scala.v1.RequestSession
+import cats.implicits.toTraverseOps
+import com.cognite.sdk.scala.v1.{Capability, RequestSession}
 import sttp.client3._
-import io.circe.Decoder
+import io.circe.{Decoder, DecodingFailure}
 import io.circe.generic.semiauto.deriveDecoder
 
 final case class ProjectDetails(projectUrlName: String, groups: Seq[Long])
 
+object ProjectDetails {
+  implicit val decoder: Decoder[ProjectDetails] = deriveDecoder[ProjectDetails]
+}
+
+sealed trait ProjectScope
+
+final case class AllProjectsScope() extends ProjectScope
+final case class ProjectUrlName(projectUrlName: String)
+final case class ProjectsListScope(projectList: Seq[ProjectUrlName]) extends ProjectScope
+
+object ProjectScope {
+  private final case class AllProjectsScopeShape(allProjects: Unit)
+  implicit val projectNameDecoder: Decoder[ProjectUrlName] = deriveDecoder
+  implicit val decoder: Decoder[ProjectScope] =
+    deriveDecoder[AllProjectsScopeShape]
+      .map(_ => AllProjectsScope())
+      .or(Decoder.decodeSeq(deriveDecoder[ProjectUrlName]).map(ProjectsListScope))
+}
+
+final case class ProjectCapability(
+    resourceAcl: Map[String, Capability],
+    projectScope: ProjectScope
+)
+
+object ProjectCapability {
+  implicit val capabilityDecoder: Decoder[Capability] = deriveDecoder
+  implicit val decoder: Decoder[ProjectCapability] = Decoder.instance { h =>
+    val keys = h.keys.map(_.toList).toList.flatten
+    val aclKeys = keys.filter(_.endsWith("Acl"))
+    for {
+      projectScope <- h.downField("projectScope").as[ProjectScope]
+      acls <- aclKeys
+        .traverse(key => h.downField(key).as[Capability].map((key, _)))
+        .map(Map.from(_))
+      _ <- Either.cond(
+        acls.sizeIs < 2,
+        (),
+        DecodingFailure(
+          DecodingFailure.Reason.CustomReason(
+            "cannot have multiple resourceAcls per capability"
+          ),
+          h.history
+        )
+      )
+      _ <- Either.cond(
+        acls.nonEmpty,
+        (),
+        DecodingFailure(
+          DecodingFailure.Reason.CustomReason("capability must have some resourceAcl"),
+          h.history
+        )
+      )
+    } yield new ProjectCapability(acls, projectScope)
+  }
+}
+
 final case class TokenInspectResponse(
     subject: String,
-    projects: Seq[ProjectDetails]
+    projects: Seq[ProjectDetails],
+    capabilities: Seq[ProjectCapability]
 )
+
+object TokenInspectResponse {
+  implicit val decoder: Decoder[TokenInspectResponse] = deriveDecoder
+}
 
 class Token[F[_]](val requestSession: RequestSession[F]) {
   @SuppressWarnings(Array("org.wartremover.warts.EitherProjectionPartial"))
-  implicit val projectDetailsDecoder: Decoder[ProjectDetails] = deriveDecoder[ProjectDetails]
-  implicit val tokenInspectResponseDecoder: Decoder[TokenInspectResponse] =
-    deriveDecoder[TokenInspectResponse]
   implicit val errorOrTokenInspectResponse: Decoder[Either[CdpApiError, TokenInspectResponse]] =
     EitherDecoder.eitherDecoder[CdpApiError, TokenInspectResponse]
   def inspect(): F[TokenInspectResponse] =

--- a/src/test/scala/com/cognite/sdk/scala/common/TokenParsingTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/TokenParsingTest.scala
@@ -1,0 +1,106 @@
+package com.cognite.sdk.scala.common
+
+import com.cognite.sdk.scala.v1.Capability
+import io.circe.literal._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class TokenParsingTest extends AnyFlatSpec with Matchers {
+  it should "decode AllProjectsScope" in {
+    val r = ProjectScope.decoder.decodeJson(json"""
+      {
+        "allProjects": {}
+      }
+    """)
+    r shouldBe Right(AllProjectsScope())
+  }
+  it should "decode ProjectsListScope" in {
+    val r = ProjectScope.decoder.decodeJson(json"""
+      [
+        {
+          "projectUrlName": "a"
+        }
+      ]
+    """)
+    r shouldBe Right(ProjectsListScope(Seq(ProjectUrlName("a"))))
+  }
+  it should "require *Acl field" in {
+    val r = ProjectCapability.decoder.decodeJson(json"""
+      {
+        "projectScope": {"allProjects": {}}
+      }
+    """)
+    r.isLeft shouldBe true
+  }
+  it should "decode allProjects capability" in {
+    val r = ProjectCapability.decoder.decodeJson(json"""
+      {
+        "AssetsAcl": {"actions": [], "scope": {}},
+        "projectScope": {"allProjects": {}}
+      }
+    """)
+    r shouldBe Right(ProjectCapability(
+      resourceAcl = Map("AssetsAcl" -> Capability(Seq(), Map())),
+      projectScope = AllProjectsScope()
+    ))
+  }
+  it should "decode projectsList capability" in {
+    val r = ProjectCapability.decoder.decodeJson(json"""
+      {
+          "AssetsAcl": {"actions": [], "scope": {}},
+          "projectScope": [{"projectUrlName": "a"}, {"projectUrlName": "b"}]
+      }
+    """)
+    r shouldBe Right(ProjectCapability(
+      resourceAcl = Map("AssetsAcl" -> Capability(Seq(), Map())),
+      projectScope = ProjectsListScope(
+        Seq(ProjectUrlName("a"), ProjectUrlName("b"))
+      )
+    ))
+  }
+  it should "decode short inspect() result" in {
+    val r = TokenInspectResponse.decoder.decodeJson(json"""
+      {
+        "subject": "s",
+        "projects": [],
+        "capabilities": []
+      }
+    """)
+    r shouldBe Right(TokenInspectResponse("s", Seq(), Seq()))
+  }
+  it should "decode full inspect() result" in {
+    val r = TokenInspectResponse.decoder.decodeJson(json"""
+      {
+        "subject": "s",
+        "projects": [
+          {"projectUrlName": "a", "groups": [1]},
+          {"projectUrlName": "b", "groups": [2]}
+        ],
+        "capabilities": [
+          {
+            "assetsAcl": {
+              "actions": ["READ"],
+              "scope": {"all": {}}
+            },
+            "projectScope": [
+              {"projectUrlName": "b"}
+            ]
+          }
+        ]
+      }
+    """)
+    r shouldBe Right(TokenInspectResponse(
+      subject = "s",
+      projects = Seq(
+        ProjectDetails("a", Seq(1)), ProjectDetails("b", Seq(2))
+      ),
+      capabilities = Seq(ProjectCapability(
+        resourceAcl = Map("assetsAcl" -> Capability(
+          actions = Seq("READ"),
+          scope = Map("all" -> Map.empty))
+        ),
+        projectScope = ProjectsListScope(Seq(ProjectUrlName("b")))
+      ))
+    ))
+  }
+}


### PR DESCRIPTION
https://api-docs.cognite.com/20230101/tag/Token/operation/inspectToken

Mostly a matter of adding custom decoders due to some shape specifics:
- `[{projectUrlName:..},..]` and `{allProjects: {}}` having different json types for same field
- `{somethingAcl: ...}` having dynamic key name
- `{somethingAcl: .., projectScope: ..}` being a combo of variable somethingAcl and projectScope

All top-level token/inspect fields are marked required in spec so should be ok to
just start parsing capabilities too.
