### PR TITLE
Drop scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,7 @@ import sbt.{Test, project}
 
 //val scala3 = "3.2.0"
 val scala213 = "2.13.8"
-val scala212 = "2.12.17"
-val supportedScalaVersions = List(scala212, scala213)
+val supportedScalaVersions = List(scala213)
 
 // This is used only for tests.
 val jettyTestVersion = "9.4.53.v20231009"
@@ -26,7 +25,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.9." + patchVersion,
+  version := "2.10." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   scalaVersion := scala213, // use 2.13 by default
   crossScalaVersions := supportedScalaVersions,


### PR DESCRIPTION

It is a bit old and there's no explicit demand to keep supporting it, while there are compiler-related workarounds that are applied to be compatible with 2.12 and 2.13 including lint warnings and being unable to use 2.13 new features.

If a case for 2.12 appears we may consider adding it back