### PR TITLE
CDF-20260: retry 409 in dms

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/sttp/RetryingBackend.scala
+++ b/src/main/scala/com/cognite/sdk/scala/sttp/RetryingBackend.scala
@@ -5,6 +5,7 @@ package com.cognite.sdk.scala.sttp
 
 import cats.effect.Temporal
 import com.cognite.sdk.scala.common.{CdpApiException, Constants, SdkException}
+import com.cognite.sdk.scala.v1.GenericClient
 import sttp.capabilities.Effect
 import sttp.client3.{Request, Response, SttpBackend, SttpClientException}
 import sttp.model.StatusCode
@@ -79,6 +80,10 @@ object RetryingBackend {
     override def shouldRetry[T, R](request: Request[T, R], statusCode: StatusCode): Boolean =
       statusCode.code match {
         case 429 | 500 | 502 | 503 | 504 => true
+        case 409
+            // 409 in dms can be transient and retriable
+            if request.tag(GenericClient.RESOURCE_TYPE_TAG).contains(GenericClient.DATAMODELS) =>
+          true
         case _ => false
       }
   }


### PR DESCRIPTION
There 409 can be transient in some cases and retries may help. Example is concurrent node auto-creation.

On top of https://github.com/cognitedata/cognite-sdk-scala/pull/708
As alternative path to https://github.com/cognitedata/cognite-sdk-scala/pull/706

[CDF-20260]

[CDF-20260]: https://cognitedata.atlassian.net/browse/CDF-20260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ