### PR TITLE
Update fdm test

### DIFF
--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -251,7 +251,14 @@ object Utils {
         case (propName, propVal) =>
           toInstanceData(sourceRef, nonNullables + (propName -> propVal))
       }
-      List(withAllProps, withRequiredProps) ++ withEachNonRequired
+      val allPropsMaps =
+        withAllProps.properties.toList ++
+        withRequiredProps.properties.toList ++
+        withEachNonRequired.flatMap(_.properties.toList)
+      List(EdgeOrNodeData(
+        source = sourceRef,
+        properties = Some(allPropsMaps.flatMap(_.toList).toMap).filterNot(_.isEmpty)
+      ))
     }
 
     EdgeWrite(
@@ -295,7 +302,14 @@ object Utils {
             case (propName, propVal) =>
               toInstanceData(sourceRef, nonNullables + (propName -> propVal))
           }
-          List(withAllProps, withRequiredProps) ++ withEachNonRequired
+          val allPropsMaps =
+            withAllProps.properties.toList ++
+              withRequiredProps.properties.toList ++
+              withEachNonRequired.flatMap(_.properties.toList)
+          List(EdgeOrNodeData(
+            source = sourceRef,
+            properties = Some(allPropsMaps.flatMap(_.toList).toMap).filterNot(_.isEmpty)
+          ))
         }
 
         EdgeWrite(


### PR DESCRIPTION
After
https://github.com/cognitedata/ark/commit/478a62a52badd5048290f7208a0fa8e056c015cd

Dms started to reject requests like
```
InstanceCreate(
  items: List(
    EdgeWrite(
      `type`: DirectRelationReference(
        space: testSpaceScalaSdk1,
        externalId: edgeExtIdsdkTest12EdgeView3
      ),
      space: testSpaceScalaSdk1,
      externalId: edgeExtIdsdkTest12EdgeView3,
      startNode: DirectRelationReference(testSpaceScalaSdk1,nodeExtIdsdkTest12NodeView4),
      endNode: DirectRelationReference(testSpaceScalaSdk1,nodeExtIdsdkTest12NodeView5),
      sources: Some(List(
        EdgeOrNodeData(
          source: ViewReference(testSpaceScalaSdk1,sdkTest12EdgeView3,v1),
          properties: Some(Map(Float64NonListWithDefaultValueNullable -> Some(Float64(0.9698695093042705)), Int32NonListWithoutAutoIncrementWithoutDefaultValueNullable -> Some(Int32(4440))))
        ),
        EdgeOrNodeData(
          source: ViewReference(testSpaceScalaSdk1,sdkTest12EdgeView3,v1),
          properties: Some(Map())
        ),
        EdgeOrNodeData(
          source: ViewReference(testSpaceScalaSdk1,sdkTest12EdgeView3,v1),
          properties: Some(Map(Float64NonListWithDefaultValueNullable -> Some(Float64(0.9698695093042705))))
        ),
        EdgeOrNodeData(
          source: ViewReference(testSpaceScalaSdk1,sdkTest12EdgeView3,v1),
          properties: Some(Map(Int32NonListWithoutAutoIncrementWithoutDefaultValueNullable -> Some(Int32(4440))))
        )
      ))
    )
  ),
  autoCreateStartNodes: Some(false),
  autoCreateEndNodes: Some(false),
  skipOnVersionConflict: Some(false),
  replace: Some(false)
)
```
https://cognitedata.slack.com/archives/C023BUN2MA7/p1701786356028409?thread_ts=1701781906.300409&cid=C023BUN2MA7

And we need to squash together `sources` properties maps for same `source`.

Let's do that in tests for now to unblock CI.
Maybe later should be lifted to sdk main code and/or add validation there as well.
