### PR TITLE
Fix usage of deprecated call

### DIFF
--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/Utils.scala
@@ -428,7 +428,7 @@ object Utils {
   private def toInstanceData(ref: SourceReference, instancePropertyValues: Map[String, InstancePropertyValue]) =
     EdgeOrNodeData(
       source = ref,
-      properties = Some(instancePropertyValues.mapValues(v => Some(v)).toMap)
+      properties = Some(instancePropertyValues.view.mapValues(v => Some(v)).toMap)
     )
 
   // scalastyle:off cyclomatic.complexity


### PR DESCRIPTION
- a warning when building popped up, suggested to use .view.MapValues