### PR TITLE
CDF-20778: add jitter to retry and backpressure throttlers

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/sttp/BackpressureThrottleBackend.scala
+++ b/src/main/scala/com/cognite/sdk/scala/sttp/BackpressureThrottleBackend.scala
@@ -34,13 +34,12 @@ class BackpressureThrottleBackend[F[_]: Temporal, +S](
       // try to take the permit and release it after the specified delay
       permit.tryTake.flatMap {
         case None => Applicative[F].unit
-        case Some(_) => {
+        case Some(_) =>
           val constantDelay = delay / 2
           val randomDelayScale = delay / 2
           val randomDelay = Random.nextInt(randomDelayScale.toMillis.toInt).millis
           Temporal[F].sleep(constantDelay + randomDelay) *>
             permit.tryOffer(()).void
-        }
       }
     } else {
       Applicative[F].unit

--- a/src/main/scala/com/cognite/sdk/scala/sttp/BackpressureThrottleBackend.scala
+++ b/src/main/scala/com/cognite/sdk/scala/sttp/BackpressureThrottleBackend.scala
@@ -9,7 +9,8 @@ import sttp.capabilities.Effect
 import sttp.client3.{Request, Response, SttpBackend}
 import sttp.monad.MonadError
 
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.util.Random
 
 /** When 429 Too many requests or 503 Service Unavailable error is encountered, new requests are
   * blocked for the specified duration
@@ -17,6 +18,9 @@ import scala.concurrent.duration.FiniteDuration
   * @param queueOf1
   *   must be a queue with one element already placed in the queue
   */
+// TODO: is this really needed compared to RetryingBackend?
+// here it can be applied across multiple services and request streams
+// which could be good or could be not so good.
 class BackpressureThrottleBackend[F[_]: Temporal, +S](
     delegate: SttpBackend[F, S],
     queueOf1: Queue[F, Unit],
@@ -30,9 +34,13 @@ class BackpressureThrottleBackend[F[_]: Temporal, +S](
       // try to take the permit and release it after the specified delay
       permit.tryTake.flatMap {
         case None => Applicative[F].unit
-        case Some(_) =>
-          Temporal[F].sleep(delay) *>
+        case Some(_) => {
+          val constantDelay = delay / 2
+          val randomDelayScale = delay / 2
+          val randomDelay = Random.nextInt(randomDelayScale.toMillis.toInt).millis
+          Temporal[F].sleep(constantDelay + randomDelay) *>
             permit.tryOffer(()).void
+        }
       }
     } else {
       Applicative[F].unit

--- a/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/RetryWhile.scala
@@ -19,15 +19,16 @@ trait RetryWhile {
       retriesRemaining: Int = 8,
       initialDelay: FiniteDuration = Constants.DefaultInitialRetryDelay
   ): A = {
-    val exponentialDelay = (Constants.DefaultMaxBackoffDelay / 2).min(initialDelay * 2)
+    val currentDelay = Random.nextInt(initialDelay.toMillis.toInt)
+    val nextDelay = Constants.DefaultMaxBackoffDelay.min(initialDelay * 2)
     Try {
       val result = action
       val _ = assertion(result)
       result
     } match {
       case Failure(_: TestFailedException) if retriesRemaining > 0 =>
-        Thread.sleep(initialDelay.toMillis + Random.nextInt(exponentialDelay.toMillis.toInt))
-        retryWithExpectedResult[A](action, assertion, retriesRemaining - 1, exponentialDelay)
+        Thread.sleep(currentDelay.toLong)
+        retryWithExpectedResult[A](action, assertion, retriesRemaining - 1, nextDelay)
       case Failure(exception) => throw exception
       case Success(value) => value
     }


### PR DESCRIPTION
- switching to FullJitter from https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/
- in backpressure throttler split fixed delay into constant half and random half
- touch src/test RetryWhile too just for more context

For later consideration: do we even need BackpressureThrottleBackend? If yes should it be improved somehow?

[CDF-20778]


[CDF-20778]: https://cognitedata.atlassian.net/browse/CDF-20778?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ