### PR TITLE
Add new unit properties in time series

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/timeSeries.scala
@@ -1,4 +1,4 @@
-// Copyright 2020 Cognite AS
+// Copyright 2024 Cognite AS
 // SPDX-License-Identifier: Apache-2.0
 
 package com.cognite.sdk.scala.v1
@@ -11,6 +11,7 @@ final case class TimeSeries(
     isString: Boolean = false,
     metadata: Option[Map[String, String]] = None,
     unit: Option[String] = None,
+    unitExternalId: Option[String] = None,
     assetId: Option[Long] = None,
     isStep: Boolean = false,
     description: Option[String] = None,
@@ -32,6 +33,7 @@ final case class TimeSeries(
       isString,
       metadata,
       unit,
+      unitExternalId,
       assetId,
       isStep,
       description,
@@ -45,6 +47,7 @@ final case class TimeSeries(
       Setter.fromOption(externalId),
       NonNullableSetter.fromOption(metadata),
       Setter.fromOption(unit),
+      Setter.fromOption(unitExternalId),
       Setter.fromOption(assetId),
       Setter.fromOption(description),
       NonNullableSetter.fromOption(securityCategories),
@@ -58,6 +61,7 @@ final case class TimeSeriesCreate(
     isString: Boolean = false,
     metadata: Option[Map[String, String]] = None,
     unit: Option[String] = None,
+    unitExternalId: Option[String] = None,
     assetId: Option[Long] = None,
     isStep: Boolean = false,
     description: Option[String] = None,
@@ -70,6 +74,7 @@ final case class TimeSeriesUpdate(
     externalId: Option[Setter[String]] = None,
     metadata: Option[NonNullableSetter[Map[String, String]]] = None,
     unit: Option[Setter[String]] = None,
+    unitExternalId: Option[Setter[String]] = None,
     assetId: Option[Setter[Long]] = None,
     description: Option[Setter[String]] = None,
     securityCategories: Option[NonNullableSetter[Seq[Long]]] = None,
@@ -79,6 +84,8 @@ final case class TimeSeriesUpdate(
 final case class TimeSeriesSearchFilter(
     name: Option[String] = None,
     unit: Option[String] = None,
+    unitExternalId: Option[String] = None,
+    unitQuantity: Option[String] = None,
     isString: Option[Boolean] = None,
     isStep: Option[Boolean] = None,
     metadata: Option[Map[String, String]] = None,
@@ -92,6 +99,8 @@ final case class TimeSeriesSearchFilter(
 final case class TimeSeriesFilter(
     name: Option[String] = None,
     unit: Option[String] = None,
+    unitExternalId: Option[String] = None,
+    unitQuantity: Option[String] = None,
     isString: Option[Boolean] = None,
     isStep: Option[Boolean] = None,
     metadata: Option[Map[String, String]] = None,

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -425,7 +425,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     syntheticQuery.head.datapoints.length should be(1000)
   }
 
-  it should "support creating and filtering timeseries with unitExternalId" in {
+  it should "support creating, updating and filtering timeseries with unitExternalId" in {
     val externalId: String = shortRandom()
     val unitExternalId: String = "temperature:deg_c"
     val timeseries = Seq(
@@ -440,6 +440,17 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     retryWithExpectedResult[TimeSeries](
       client.timeSeries.retrieveByExternalId(externalId).unsafeRunSync(),
         r => r.unitExternalId shouldBe Some(unitExternalId)
+    )
+
+    // make sure we can update the timeseries with a new unitExternalId
+    val newUnitExternalId = "temperature:deg_f"
+    val update = Map(externalId -> TimeSeriesUpdate(unitExternalId = Some(SetValue(newUnitExternalId))))
+    val _ = client.timeSeries.updateByExternalId(update).unsafeRunSync()
+
+    // make sure we can retrieve the timeseries by externalId and it has the updated unitExternalId
+    retryWithExpectedResult[TimeSeries](
+      client.timeSeries.retrieveByExternalId(externalId).unsafeRunSync(),
+        r => r.unitExternalId shouldBe Some(newUnitExternalId)
     )
 
     // make sure we can filter by unitExternalId

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -456,7 +456,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     // make sure we can filter by unitExternalId
     retryWithExpectedResult[Seq[TimeSeries]](
       client.timeSeries.filter(
-        TimeSeriesFilter(unitExternalId = Some(unitExternalId))
+        TimeSeriesFilter(unitExternalId = Some(newUnitExternalId))
       ).compile.toList.unsafeRunSync(),
       r => r should not be empty
     )

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -434,7 +434,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
         unitExternalId = Some(unitExternalId)
       )
     )
-    val _ = client.timeSeries.create(timeseries).unsafeRunSync()
+    val tsCreated = client.timeSeries.create(timeseries).unsafeRunSync()
 
     // make sure we can retrieve the timeseries by externalId and it has the correct unitExternalId
     retryWithExpectedResult[TimeSeries](
@@ -445,7 +445,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     // make sure we can update the timeseries with a new unitExternalId
     val newUnitExternalId = "temperature:deg_f"
     val update = Map(externalId -> TimeSeriesUpdate(unitExternalId = Some(SetValue(newUnitExternalId))))
-    val _ = client.timeSeries.updateByExternalId(update).unsafeRunSync()
+    val tsUpdated = client.timeSeries.updateByExternalId(update).unsafeRunSync()
 
     // make sure we can retrieve the timeseries by externalId and it has the updated unitExternalId
     retryWithExpectedResult[TimeSeries](

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -434,7 +434,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
         unitExternalId = Some(unitExternalId)
       )
     )
-    val tsCreated = client.timeSeries.create(timeseries).unsafeRunSync()
+    client.timeSeries.create(timeseries).unsafeRunSync()
 
     // make sure we can retrieve the timeseries by externalId and it has the correct unitExternalId
     retryWithExpectedResult[TimeSeries](
@@ -445,7 +445,7 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     // make sure we can update the timeseries with a new unitExternalId
     val newUnitExternalId = "temperature:deg_f"
     val update = Map(externalId -> TimeSeriesUpdate(unitExternalId = Some(SetValue(newUnitExternalId))))
-    val tsUpdated = client.timeSeries.updateByExternalId(update).unsafeRunSync()
+    client.timeSeries.updateByExternalId(update).unsafeRunSync()
 
     // make sure we can retrieve the timeseries by externalId and it has the updated unitExternalId
     retryWithExpectedResult[TimeSeries](

--- a/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/TimeSeriesTest.scala
@@ -424,4 +424,41 @@ class TimeSeriesTest extends SdkTestSpec with ReadBehaviours with WritableBehavi
     val syntheticQuery: Id[Seq[SyntheticTimeSeriesResponse]] = client.timeSeries.syntheticQuery(Items(Seq(query))).unsafeRunSync()
     syntheticQuery.head.datapoints.length should be(1000)
   }
+
+  it should "support creating and filtering timeseries with unitExternalId" in {
+    val externalId: String = shortRandom()
+    val unitExternalId: String = "temperature:deg_c"
+    val timeseries = Seq(
+      TimeSeriesCreate(
+        externalId = Some(externalId),
+        unitExternalId = Some(unitExternalId)
+      )
+    )
+    val _ = client.timeSeries.create(timeseries).unsafeRunSync()
+
+    // make sure we can retrieve the timeseries by externalId and it has the correct unitExternalId
+    retryWithExpectedResult[TimeSeries](
+      client.timeSeries.retrieveByExternalId(externalId).unsafeRunSync(),
+        r => r.unitExternalId shouldBe Some(unitExternalId)
+    )
+
+    // make sure we can filter by unitExternalId
+    retryWithExpectedResult[Seq[TimeSeries]](
+      client.timeSeries.filter(
+        TimeSeriesFilter(unitExternalId = Some(unitExternalId))
+      ).compile.toList.unsafeRunSync(),
+      r => r should not be empty
+    )
+
+    // make sure we can filter by unitQuantity
+    retryWithExpectedResult[Seq[TimeSeries]](
+      client.timeSeries.filter(
+        TimeSeriesFilter(unitQuantity = Some("Temperature"))
+      ).compile.toList.unsafeRunSync(),
+      r => r should not be empty
+    )
+
+    // clean up
+    client.timeSeries.delete(Seq(CogniteExternalId(externalId)), true).unsafeRunSync()
+  }
 }


### PR DESCRIPTION
This PR adds the new time series properties related to the new unit management features in CDF:
- added `unitExternalId` property for creation/update of time series 
- added `unitExternalId` on the response for time series
- added `unitExternalId` and `unitQuantity` for filtering time series