### PR TITLE
fdm: split /query and /sync response types

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.20." + patchVersion,
+  version := "2.21." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   scalaVersion := scala213, // use 2.13 by default
   // handle cross plugin https://github.com/stringbean/sbt-dependency-lock/issues/13

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceDataResponsePart.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceDataResponsePart.scala
@@ -4,19 +4,17 @@ import cats.implicits.toTraverseOps
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.{Decoder, Encoder, HCursor, Json}
 
-final case class InstanceDataResponse(
+final case class InstanceDataResponsePart(
     items: Option[Map[String, Seq[InstanceDefinition]]] = None,
-    nextCursor: Option[Map[String, String]] = None,
     typing: Option[Map[String, Map[String, Map[String, Map[String, TypePropertyDefinition]]]]] =
       None
 )
 
-object InstanceDataResponse {
-  implicit val instanceDataResponseEncoder: Encoder[InstanceDataResponse] = deriveEncoder
+object InstanceDataResponsePart {
+  val instanceDataResponsePartEncoder: Encoder[InstanceDataResponsePart] = deriveEncoder
 
-  implicit val instanceDataResponseDecoder: Decoder[InstanceDataResponse] = (c: HCursor) =>
+  val instanceDataResponsePartDecoder: Decoder[InstanceDataResponsePart] = (c: HCursor) =>
     for {
-      nextCursor <- c.downField("nextCursor").as[Option[Map[String, String]]]
       typing <- c
         .downField("typing")
         .as[Option[Map[String, Map[String, Map[String, Map[String, TypePropertyDefinition]]]]]]
@@ -42,5 +40,5 @@ object InstanceDataResponse {
         }
         .traverse(decodeResult => decodeResult)
 
-    } yield InstanceDataResponse(items, nextCursor, typing)
+    } yield InstanceDataResponsePart(items, typing)
 }

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceQueryResponse.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceQueryResponse.scala
@@ -1,0 +1,23 @@
+package com.cognite.sdk.scala.v1.fdm.instances
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.deriveEncoder
+
+final case class InstanceQueryResponse(
+    items: Option[Map[String, Seq[InstanceDefinition]]] = None,
+    typing: Option[Map[String, Map[String, Map[String, Map[String, TypePropertyDefinition]]]]] =
+      None,
+    nextCursor: Option[Map[String, String]] = None
+) {
+  def getDataPart(): InstanceDataResponsePart = InstanceDataResponsePart(items, typing)
+}
+
+object InstanceQueryResponse {
+  implicit val instanceQueryResponseEncoder: Encoder[InstanceQueryResponse] = deriveEncoder
+  implicit val instanceQueryResponseDecoder: Decoder[InstanceQueryResponse] =
+    InstanceDataResponsePart.instanceDataResponsePartDecoder
+      .product(
+        _.downField("nextCursor").as[Option[Map[String, String]]]
+      )
+      .map { case (data, cursor) => InstanceQueryResponse(data.items, data.typing, cursor) }
+}

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceSyncResponse.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceSyncResponse.scala
@@ -1,0 +1,24 @@
+package com.cognite.sdk.scala.v1.fdm.instances
+
+import io.circe.{Decoder, Encoder}
+import io.circe.generic.semiauto.deriveEncoder
+
+final case class InstanceSyncResponse(
+    items: Option[Map[String, Seq[InstanceDefinition]]] = None,
+    typing: Option[Map[String, Map[String, Map[String, Map[String, TypePropertyDefinition]]]]] =
+      None,
+    nextCursor: Map[String, String] = Map.empty
+) {
+  def getDataPart(): InstanceDataResponsePart = InstanceDataResponsePart(items, typing)
+
+}
+
+object InstanceSyncResponse {
+  implicit val instanceSyncResponseEncoder: Encoder[InstanceSyncResponse] = deriveEncoder
+  implicit val instanceSyncResponseDecoder: Decoder[InstanceSyncResponse] =
+    InstanceDataResponsePart.instanceDataResponsePartDecoder
+      .product(
+        _.downField("nextCursor").as[Map[String, String]]
+      )
+      .map { case (data, cursor) => InstanceSyncResponse(data.items, data.typing, cursor) }
+}

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
@@ -41,15 +41,15 @@ class Instances[F[_]](val requestSession: RequestSession[F])
       identity
     )
 
-  def syncRequest(syncRequest: InstanceSyncRequest): F[InstanceDataResponse] =
-    requestSession.post[InstanceDataResponse, InstanceDataResponse, InstanceSyncRequest](
+  def syncRequest(syncRequest: InstanceSyncRequest): F[InstanceSyncResponse] =
+    requestSession.post[InstanceSyncResponse, InstanceSyncResponse, InstanceSyncRequest](
       syncRequest,
       uri"$baseUrl/sync",
       identity
     )
 
-  def queryRequest(queryRequest: InstanceQueryRequest): F[InstanceDataResponse] =
-    requestSession.post[InstanceDataResponse, InstanceDataResponse, InstanceQueryRequest](
+  def queryRequest(queryRequest: InstanceQueryRequest): F[InstanceQueryResponse] =
+    requestSession.post[InstanceQueryResponse, InstanceQueryResponse, InstanceQueryRequest](
       queryRequest,
       uri"$baseUrl/query",
       identity

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceSyncSerDerTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstanceSyncSerDerTest.scala
@@ -250,8 +250,8 @@ class InstanceSyncSerDerTest extends AnyWordSpec with Matchers {
       val items: Map[String, Seq[InstanceDefinition]] = Map("sync1" -> expectedItems)
       val cursors = Map[String, String]("sync1" -> "cursor-101")
 
-      val actual: Either[circe.Error, InstanceDataResponse] = parse(encoded).flatMap(Decoder[InstanceDataResponse].decodeJson)
-      Right(Some(cursors)) shouldBe actual.map(_.nextCursor)
+      val actual: Either[circe.Error, InstanceSyncResponse] = parse(encoded).flatMap(Decoder[InstanceSyncResponse].decodeJson)
+      Right(cursors) shouldBe actual.map(_.nextCursor)
       Right(Some(items)) shouldBe actual.map(_.items)
     }
 
@@ -287,10 +287,11 @@ class InstanceSyncSerDerTest extends AnyWordSpec with Matchers {
           |                 }
           |             }
           |          }
-          |    }
+          |    },
+          |    "nextCursor": {}
           |}""".stripMargin
       print (json)
-      val actual: Either[circe.Error, InstanceDataResponse] = parse(json).flatMap(Decoder[InstanceDataResponse].decodeJson)
+      val actual: Either[circe.Error, InstanceSyncResponse] = parse(json).flatMap(Decoder[InstanceSyncResponse].decodeJson)
 
       actual match {
         case Left(value) => throw new Exception(value)
@@ -711,8 +712,8 @@ class InstanceSyncSerDerTest extends AnyWordSpec with Matchers {
       val items: Map[String, Seq[InstanceDefinition]] = Map("sync1" -> expectedItems)
       val cursors = Map[String, String]("sync1" -> "cursor-101")
 
-      val actual: Either[circe.Error, InstanceDataResponse] = parse(encoded).flatMap(Decoder[InstanceDataResponse].decodeJson)
-      Right(Some(cursors)) shouldBe actual.map(_.nextCursor)
+      val actual: Either[circe.Error, InstanceSyncResponse] = parse(encoded).flatMap(Decoder[InstanceSyncResponse].decodeJson)
+      Right(cursors) shouldBe actual.map(_.nextCursor)
       Right(Some(items)) shouldBe actual.map(_.items)
     }
   }

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesSyncIntegrationTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesSyncIntegrationTest.scala
@@ -117,8 +117,8 @@ class InstancesSyncIntegrationTest extends CommonDataModelTestHelper {
     testClient.instances.delete(nodesToDelete).unsafeRunSync()
   }
 
-  private def syncAndValidate(viewRef: ViewReference, expected: Seq[String], cursor: Option[Map[String, String]], deleted: Boolean = false) = {
-    val syncResponse = syncNodeInstances(viewRef, cursor).unsafeRunSync()
+  private def syncAndValidate(viewRef: ViewReference, expected: Seq[String], cursor: Map[String, String], deleted: Boolean = false) = {
+    val syncResponse = syncNodeInstances(viewRef, Some(cursor)).unsafeRunSync()
     val nodes: Seq[NodeDefinition] = syncResponse.items.get("sync").asInstanceOf[Seq[NodeDefinition]]
     nodes.size shouldBe expected.size
     nodes.map(_.externalId) should contain theSameElementsAs expected
@@ -127,11 +127,12 @@ class InstancesSyncIntegrationTest extends CommonDataModelTestHelper {
   }
 
   @scala.annotation.tailrec
-  private def syncToHead(viewRef: ViewReference, cursor: Option[Map[String, String]] = None): Option[Map[String, String]] = {
+  private def syncToHead(viewRef: ViewReference, cursor: Option[Map[String, String]] = None)
+  : Map[String, String] = {
     val syncResponse = syncNodeInstances(viewRef, cursor).unsafeRunSync()
     val nodes: Seq[NodeDefinition] = syncResponse.items.get("sync").asInstanceOf[Seq[NodeDefinition]]
     if (nodes.nonEmpty) {
-      syncToHead(viewRef, syncResponse.nextCursor)
+      syncToHead(viewRef, Some(syncResponse.nextCursor))
     } else {
       syncResponse.nextCursor
     }

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -142,30 +142,33 @@ class InstancesTest extends CommonDataModelTestHelper {
 
     val readNodesMapOfNode1 = (IO.sleep(10.seconds) *> fetchNodeInstance(nodeView1.toSourceReference, node1WriteData.externalId)).unsafeRunSync()
     val readNodesMapOfNode2 = fetchNodeInstance(nodeView2.toSourceReference, node2WriteData.externalId).unsafeRunSync()
-    val syncNodesMapOfNodeView1: InstanceDataResponse = syncNodeInstances(nodeView1.toSourceReference).unsafeRunSync()
+    val syncNodesMapOfNodeView1: InstanceSyncResponse = syncNodeInstances(nodeView1.toSourceReference)
+      .unsafeRunSync()
     val syncNodesMapOfNodeView2 = syncNodeInstances(nodeView2.toSourceReference).unsafeRunSync()
 
-    syncNodesMapOfNodeView1.nextCursor.map { map =>
+    syncNodesMapOfNodeView1.nextCursor match { case map =>
       map.size shouldBe 1
-      map.keys.find("sync" === _).isDefined shouldBe true
+      map.keys.exists("sync" === _) shouldBe true
     }
 
-    syncNodesMapOfNodeView2.nextCursor.map { map =>
+    syncNodesMapOfNodeView2.nextCursor match { case map =>
       map.size shouldBe 1
-      map.keys.find("sync" === _).isDefined shouldBe true
+      map.keys.exists("sync" === _) shouldBe true
     }
 
-    val queryNodesMapOfNodeView1: InstanceDataResponse = queryNodeInstances(nodeView1.toSourceReference).unsafeRunSync()
-    val queryNodesMapOfNodeView2 = queryNodeInstances(nodeView2.toSourceReference).unsafeRunSync()
+    val queryNodesMapOfNodeView1: InstanceQueryResponse = queryNodeInstances(nodeView1.toSourceReference)
+      .unsafeRunSync()
+    val queryNodesMapOfNodeView2: InstanceQueryResponse = queryNodeInstances(nodeView2.toSourceReference)
+      .unsafeRunSync()
 
     queryNodesMapOfNodeView1.nextCursor.map { map =>
       map.size shouldBe 1
-      map.keys.find("query" === _).isDefined shouldBe true
+      map.keys.exists("query" === _) shouldBe true
     }
 
     queryNodesMapOfNodeView2.nextCursor.map { map =>
       map.size shouldBe 1
-      map.keys.find("query" === _).isDefined shouldBe true
+      map.keys.exists("query" === _) shouldBe true
     }
 
     val readEdgesMapOfEdge = fetchEdgeInstance(edgeView.toSourceReference, edgeWriteData.externalId).unsafeRunSync()


### PR DESCRIPTION
In /sync response `nextCursor` is always present
https://api-docs.cognite.com/20230101/tag/Instances/operation/syncContent#!c=200&path=nextCursor&t=response
because /sync can stream indefinitely long. Consumer may stop
at will, for example when receiving and empty results page.

While in /query `nextCursor` is optional
https://api-docs.cognite.com/20230101/tag/Instances/operation/queryContent#!c=200&path=nextCursor&t=response
because /query iteration eventually stops after getting all results.

Note: there seems to be a bug in /query documentation
