### PR TITLE
Add head verb

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -149,7 +149,7 @@ final case class RequestSession[F[_]: Monad: Trace](
 
   def head(
       uri: Uri
-  )(): F[Seq[Header]] =
+  ): F[Seq[Header]] =
     sttpRequest
       .head(uri)
       .send(sttpBackend)

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -147,6 +147,14 @@ final case class RequestSession[F[_]: Monad: Trace](
       .send(sttpBackend)
       .map(_.body)
 
+  def head(
+      uri: Uri
+  )(): F[Seq[Header]] =
+    sttpRequest
+      .head(uri)
+      .send(sttpBackend)
+      .map(_.headers)
+
   def sendCdf[R](
       r: RequestT[Empty, Either[String, String], Any] => RequestT[Id, R, Any],
       contentType: String = "application/json",

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -417,7 +417,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
   }
 
   it should "send a head request and return the headers" in {
-    client.requestSession.head(uri"https://www.cognite.com/")().unsafeRunSync() should not be(empty)
+    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
   }
 
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -416,4 +416,8 @@ class ClientTest extends SdkTestSpec with OptionValues {
     }
   }
 
+  it should "send a head request and return the headers" in {
+    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
+  }
+
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -417,7 +417,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
   }
 
   it should "send a head request and return the headers" in {
-    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
+    client.requestSession.head(uri"https://www.cognite.com/")().unsafeRunSync() should not be(empty)
   }
 
 }


### PR DESCRIPTION
Going to be used for file content to get headers when querying the uri returned by files.

It allows us to use the same client to send it, with the benefit that come with it (x headers, potential tracing etc...)