### PR TITLE
attempting to add headers and add test

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -150,12 +150,13 @@ final case class RequestSession[F[_]: Monad: Trace](
   def head(
       uri: Uri,
       headers: Seq[Header] = Seq()
-  ): F[Seq[Header]] =
+  ): F[Any] =
     sttpRequest
       .headers(headers: _*)
-      .head(uri)
+      .get(uri)
       .send(sttpBackend)
-      .map(_.headers)
+      .map(_.body)
+
 
   def sendCdf[R](
       r: RequestT[Empty, Either[String, String], Any] => RequestT[Id, R, Any],

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -150,13 +150,12 @@ final case class RequestSession[F[_]: Monad: Trace](
   def head(
       uri: Uri,
       headers: Seq[Header] = Seq()
-  ): F[Any] =
+  ): F[Seq[Header]] =
     sttpRequest
       .headers(headers: _*)
-      .get(uri)
+      .head(uri)
       .send(sttpBackend)
-      .map(_.body)
-
+      .map(_.headers)
 
   def sendCdf[R](
       r: RequestT[Empty, Either[String, String], Any] => RequestT[Id, R, Any],

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -149,10 +149,10 @@ final case class RequestSession[F[_]: Monad: Trace](
 
   def head(
       uri: Uri,
-      headers: Seq[Header] = Seq()
+      overrideHeaders: Seq[Header] = Seq()
   ): F[Seq[Header]] =
     sttpRequest
-      .headers(headers: _*)
+      .headers(overrideHeaders: _*)
       .head(uri)
       .send(sttpBackend)
       .map(_.headers)

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -3,18 +3,19 @@
 
 package com.cognite.sdk.scala.v1
 
-import com.cognite.scala_sdk.BuildInfo
 import cats.implicits._
 import cats.{Id, Monad}
+import com.cognite.scala_sdk.BuildInfo
 import com.cognite.sdk.scala.common._
 import com.cognite.sdk.scala.v1.GenericClient.parseResponse
 import com.cognite.sdk.scala.v1.resources._
-import com.cognite.sdk.scala.v1.resources.fdm.datamodels.{DataModels => DataModelsV3}
 import com.cognite.sdk.scala.v1.resources.fdm.containers.Containers
+import com.cognite.sdk.scala.v1.resources.fdm.datamodels.{DataModels => DataModelsV3}
 import com.cognite.sdk.scala.v1.resources.fdm.instances.Instances
 import com.cognite.sdk.scala.v1.resources.fdm.views.Views
 import io.circe.Decoder
 import io.circe.generic.semiauto.deriveDecoder
+import natchez.Trace
 import sttp.capabilities.Effect
 import sttp.client3._
 import sttp.client3.circe.asJsonEither
@@ -24,7 +25,6 @@ import sttp.monad.MonadError
 import java.net.{InetAddress, UnknownHostException}
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-import natchez.Trace
 
 class TraceSttpBackend[F[_]: Trace, +P](delegate: SttpBackend[F, P]) extends SttpBackend[F, P] {
 
@@ -146,6 +146,16 @@ final case class RequestSession[F[_]: Monad: Trace](
       .response(parseResponse(uri, mapResult))
       .send(sttpBackend)
       .map(_.body)
+
+  def head(
+      uri: Uri,
+      headers: Seq[Header] = Seq()
+  ): F[Seq[Header]] =
+    sttpRequest
+      .headers(headers: _*)
+      .head(uri)
+      .send(sttpBackend)
+      .map(_.headers)
 
   def sendCdf[R](
       r: RequestT[Empty, Either[String, String], Any] => RequestT[Id, R, Any],

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -23,12 +23,7 @@ import java.util.Base64
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
-@SuppressWarnings(Array(
-  "org.wartremover.warts.NonUnitStatements",
-  "org.wartremover.warts.Var",
-  "org.wartremover.warts.ThreadSleep",
-  "org.wartremover.warts.While")
-)
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Var"))
 class ClientTest extends SdkTestSpec with OptionValues {
   private val tokenInspectResponse = Response(
     s"""

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -447,7 +447,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
 
     val link = client.files.downloadLink(FileDownloadId(file.id)).unsafeRunSync()
 
-    val headers = client.requestSession.head(uri"$link", Seq(Header("Accept-Encoding", "gzip"))).unsafeRunSync()
+    val headers = client.requestSession.head(uri"$link", Seq(Header("Accept-Encoding", ""))).unsafeRunSync()
     val headers2 = client.requestSession.head(uri"$link").unsafeRunSync()
     headers should contain(headers2)
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -419,43 +419,16 @@ class ClientTest extends SdkTestSpec with OptionValues {
     }
   }
 
-  it should "send a head request and return the headers" in {
-    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
-  }
+//  it should "send a head request and return the headers" in {
+//    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
+//  }
 
 
   it should "send a head request and return the headers with header" in {
-    //we create a file and send it in order to be able to check content encoding on the file upload link side of things
-    //what we want to check is that this header, which is set by default, can be overriden to empty
-    val file =
-      client.files.upload(
-        new java.io.File("./src/test/scala/com/cognite/sdk/scala/v1/uploadTest.txt")
-      ).unsafeRunSync()
+    val headers = client.requestSession.head(uri"https://postman-echo.com/headers", Seq(Header("Accept-Encoding", "gzip"))).unsafeRunSync()
+    val headers2 = client.requestSession.head(uri"https://postman-echo.com/headers").unsafeRunSync()
 
-
-    var uploadedFile = client.files.retrieveByIds(Seq(file.id)).unsafeRunSync()
-    var retryCount = 0
-    while (!uploadedFile.headOption
-      .getOrElse(throw new RuntimeException("File was not uploaded in test"))
-      .uploaded) {
-      retryCount += 1
-      Thread.sleep(500)
-      uploadedFile = client.files.retrieveByIds(Seq(file.id)).unsafeRunSync()
-      if (retryCount > 10) {
-        throw new RuntimeException("File is not uploaded after 10 retries in test")
-      }
-    }
-
-    val link = client.files.downloadLink(FileDownloadId(file.id)).unsafeRunSync()
-
-    val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", "deflate, identity;q=0"))).unsafeRunSync()
-    val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
-
-    headers.filter(_.name.equalsIgnoreCase("Content-Encoding")) should contain theSameElementsAs headers2.filter(_.name.equalsIgnoreCase("Content-Encoding"))
-
-    link.downloadUrl shouldNot be(empty)
-    client.files.deleteById(file.id).unsafeRunSync()
-
+    headers should be(headers2)
   }
 
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -448,7 +448,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
 
     val link = client.files.downloadLink(FileDownloadId(file.id)).unsafeRunSync()
 
-    val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", ""))).unsafeRunSync()
+    val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", "deflate, identity;q=0"))).unsafeRunSync()
     val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
 
     headers.filter(_.name.equalsIgnoreCase("Content-Encoding")) should contain theSameElementsAs headers2.filter(_.name.equalsIgnoreCase("Content-Encoding"))

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -419,16 +419,43 @@ class ClientTest extends SdkTestSpec with OptionValues {
     }
   }
 
-//  it should "send a head request and return the headers" in {
-//    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
-//  }
+  it should "send a head request and return the headers" in {
+    client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
+  }
 
 
   it should "send a head request and return the headers with header" in {
-    val headers = client.requestSession.head(uri"https://postman-echo.com/headers", Seq(Header("Accept-Encoding", "gzip"))).unsafeRunSync()
-    val headers2 = client.requestSession.head(uri"https://postman-echo.com/headers").unsafeRunSync()
+    //we create a file and send it in order to be able to check content encoding on the file upload link side of things
+    //what we want to check is that this header, which is set by default, can be overriden to empty
+    val file =
+      client.files.upload(
+        new java.io.File("./src/test/scala/com/cognite/sdk/scala/v1/uploadTest.txt")
+      ).unsafeRunSync()
 
-    headers should be(headers2)
+
+    var uploadedFile = client.files.retrieveByIds(Seq(file.id)).unsafeRunSync()
+    var retryCount = 0
+    while (!uploadedFile.headOption
+      .getOrElse(throw new RuntimeException("File was not uploaded in test"))
+      .uploaded) {
+      retryCount += 1
+      Thread.sleep(500)
+      uploadedFile = client.files.retrieveByIds(Seq(file.id)).unsafeRunSync()
+      if (retryCount > 10) {
+        throw new RuntimeException("File is not uploaded after 10 retries in test")
+      }
+    }
+
+    val link = client.files.downloadLink(FileDownloadId(file.id)).unsafeRunSync()
+
+    val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", "deflate, identity;q=0"))).unsafeRunSync()
+    val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
+
+    headers.filter(_.name.equalsIgnoreCase("Content-Encoding")) should contain theSameElementsAs headers2.filter(_.name.equalsIgnoreCase("Content-Encoding"))
+
+    link.downloadUrl shouldNot be(empty)
+    client.files.deleteById(file.id).unsafeRunSync()
+
   }
 
 }

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -22,6 +22,7 @@ import java.time.Instant
 import java.util.Base64
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
+import scala.collection.immutable.Seq
 
 @SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Var"))
 class ClientTest extends SdkTestSpec with OptionValues {

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -426,6 +426,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
 
   it should "send a head request and return the headers with header" in {
     //we create a file and send it in order to be able to check content encoding on the file upload link side of things
+    //what we want to check is that this header, which is set by default, can be overriden to empty
     val file =
       client.files.upload(
         new java.io.File("./src/test/scala/com/cognite/sdk/scala/v1/uploadTest.txt")
@@ -447,8 +448,8 @@ class ClientTest extends SdkTestSpec with OptionValues {
 
     val link = client.files.downloadLink(FileDownloadId(file.id)).unsafeRunSync()
 
-    val headers = client.requestSession.head(uri"$link", Seq(Header("Accept-Encoding", ""))).unsafeRunSync()
-    val headers2 = client.requestSession.head(uri"$link").unsafeRunSync()
+    val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", ""))).unsafeRunSync()
+    val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
     headers should contain(headers2)
 
     link.downloadUrl shouldNot be(empty)

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -451,7 +451,7 @@ class ClientTest extends SdkTestSpec with OptionValues {
     val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", ""))).unsafeRunSync()
     val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
 
-    headers.filter(_.name == "Content-Encoding") should contain theSameElementsAs headers2.filter(_.name == "Content-Encoding")
+    headers.filter(_.name.equalsIgnoreCase("Content-Encoding")) should contain theSameElementsAs headers2.filter(_.name.equalsIgnoreCase("Content-Encoding"))
 
     link.downloadUrl shouldNot be(empty)
     client.files.deleteById(file.id).unsafeRunSync()

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -450,7 +450,8 @@ class ClientTest extends SdkTestSpec with OptionValues {
 
     val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", ""))).unsafeRunSync()
     val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
-    headers should contain(headers2)
+
+    headers.filter(_.name == "Content-Encoding") should contain theSameElementsAs headers2.filter(_.name == "Content-Encoding")
 
     link.downloadUrl shouldNot be(empty)
     client.files.deleteById(file.id).unsafeRunSync()

--- a/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/ClientTest.scala
@@ -422,40 +422,4 @@ class ClientTest extends SdkTestSpec with OptionValues {
   it should "send a head request and return the headers" in {
     client.requestSession.head(uri"https://www.cognite.com/").unsafeRunSync() should not be(empty)
   }
-
-
-  it should "send a head request and return the headers with header" in {
-    //we create a file and send it in order to be able to check content encoding on the file upload link side of things
-    //what we want to check is that this header, which is set by default, can be overriden to empty
-    val file =
-      client.files.upload(
-        new java.io.File("./src/test/scala/com/cognite/sdk/scala/v1/uploadTest.txt")
-      ).unsafeRunSync()
-
-
-    var uploadedFile = client.files.retrieveByIds(Seq(file.id)).unsafeRunSync()
-    var retryCount = 0
-    while (!uploadedFile.headOption
-      .getOrElse(throw new RuntimeException("File was not uploaded in test"))
-      .uploaded) {
-      retryCount += 1
-      Thread.sleep(500)
-      uploadedFile = client.files.retrieveByIds(Seq(file.id)).unsafeRunSync()
-      if (retryCount > 10) {
-        throw new RuntimeException("File is not uploaded after 10 retries in test")
-      }
-    }
-
-    val link = client.files.downloadLink(FileDownloadId(file.id)).unsafeRunSync()
-
-    val headers = client.requestSession.head(uri"${link.downloadUrl}", Seq(Header("Accept-Encoding", "deflate, identity;q=0"))).unsafeRunSync()
-    val headers2 = client.requestSession.head(uri"${link.downloadUrl}").unsafeRunSync()
-
-    headers.filter(_.name.equalsIgnoreCase("Content-Encoding")) should contain theSameElementsAs headers2.filter(_.name.equalsIgnoreCase("Content-Encoding"))
-
-    link.downloadUrl shouldNot be(empty)
-    client.files.deleteById(file.id).unsafeRunSync()
-
-  }
-
 }


### PR DESCRIPTION
I tried various approaches to test this feature, including:

 * request with different headers to cognite.com => no way to know which headers were sent
 * request to files with gzip disabled/enabled => seems like the file download endpoint doesn't compress, at least not for small files

In the end I gave up, but not before trying to see if the headers were correctly overriden using https://www.postman.com/postman/published-postman-templates/documentation/ae2ja6x/postman-echo?ctx=documentation and they are so this should be working right... but not sure how to test it properly without refactor