### PR TITLE
Expose filtering fields with null values from Raw

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -40,7 +40,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.30." + patchVersion,
+  version := "2.31." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   scalaVersion := scala213, // use 2.13 by default
   // handle cross plugin https://github.com/stringbean/sbt-dependency-lock/issues/13

--- a/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/Client.scala
@@ -237,8 +237,8 @@ class GenericClient[F[_]: Trace](
     new RawDatabases[F](requestSession.withResourceType(RAW_METADATA))
   def rawTables(database: String): RawTables[F] =
     new RawTables(requestSession.withResourceType(RAW_METADATA), database)
-  def rawRows(database: String, table: String): RawRows[F] =
-    new RawRows(requestSession.withResourceType(RAW_ROWS), database, table)
+  def rawRows(database: String, table: String, filterNullFields: Boolean = false): RawRows[F] =
+    new RawRows(requestSession.withResourceType(RAW_ROWS), database, table, filterNullFields)
 
   lazy val threeDModels = new ThreeDModels[F](requestSession.withResourceType(THREED))
   def threeDRevisions(modelId: Long): ThreeDRevisions[F] =

--- a/src/test/scala/com/cognite/sdk/scala/v1/RawTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/RawTest.scala
@@ -15,7 +15,8 @@ import sttp.client3.UriContext
   Array(
     "org.wartremover.warts.TraversableOps",
     "org.wartremover.warts.NonUnitStatements",
-    "org.wartremover.warts.IterableOps"
+    "org.wartremover.warts.IterableOps",
+    "org.wartremover.warts.SizeIs"
   )
 )
 class RawTest extends SdkTestSpec with ReadBehaviours with WritableBehaviors with OptionValues {


### PR DESCRIPTION
This exposes the query parameter to control whether Raw should return fields where the value is null or not. After several failed tries, it does this through the RawRows constructor, as this is also relevant for clients that do not filter the output (so it can't just be part of RawRowsFilter, sadly). The filter is simply not a query filter, like the other components of RawRowsFilter.