### PR TITLE
CDF-23558: retry on status=408 too

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/sttp/RetryingBackend.scala
+++ b/src/main/scala/com/cognite/sdk/scala/sttp/RetryingBackend.scala
@@ -78,7 +78,7 @@ object RetryingBackend {
   val DefaultShouldRetryPredicate: ShouldRetryPredicate = new ShouldRetryPredicate {
     override def shouldRetry[T, R](request: Request[T, R], statusCode: StatusCode): Boolean =
       statusCode.code match {
-        case 429 | 500 | 502 | 503 | 504 => true
+        case 408 | 429 | 500 | 502 | 503 | 504 => true
         case 409
             // 409 in dms can be transient and retriable
             if request.tag(GenericClient.RESOURCE_TYPE_TAG).contains(GenericClient.DATAMODELS) =>


### PR DESCRIPTION
HTTP status code 408 is server-side indication of timeout rather than client giving up on waiting.
We should retry those too, client-side timeouts are retried already.

[CDF-23558]


[CDF-23558]: https://cognitedata.atlassian.net/browse/CDF-23558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ