### PR TITLE
Fully drop scala 2.12 workflow

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -7,49 +7,6 @@ on:
     branches: [ master ]
 
 jobs:
-  compile_scala_212:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
-    environment: CI
-
-    timeout-minutes: 20
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
-      - run: |
-          git rev-list --count --first-parent HEAD > patch_version.txt
-
-      - name: Set up JDK 8
-        uses: coursier/setup-action@039f736548afa5411c1382f40a5bd9c2d30e0383 # v1.3.9
-        with:
-          jvm: adopt:8
-          apps: sbt
-
-      # Caching dependencies in Pull Requests based on branch name and build.sbt.
-      # Can we do something better here?
-      - name: Cache Coursier dependencies
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        env:
-          cache-name: coursier-cache
-        with:
-          path: ~/.cache/coursier/v1
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.head_ref }}-${{ hashFiles('**/build.sbt') }}
-
-      - name: Cache Ivy 2 cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        env:
-          cache-name: sbt-ivy2-cache
-        with:
-          path: ~/.ivy2/cache
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ github.head_ref }}-${{ hashFiles('**/build.sbt') }}
-
-      # temp workaround for 2.12 job being required, removed it when required checks are tuned
-      - name: Compile
-        run: |
-          true
-
   compile_scala_213:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'


### PR DESCRIPTION
2.12 CI check is no longer "required" so we can fully drop it now