### PR TITLE
Replace oss.sonatype.org with ossrh-staging-api.central.sonatype.com

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,7 +25,7 @@ lazy val patchVersion = scala.io.Source.fromFile("patch_version.txt").mkString.t
 
 credentials += Credentials(
   "Sonatype Nexus Repository Manager",
-  "oss.sonatype.org",
+  "ossrh-staging-api.central.sonatype.com",
   System.getenv("SONATYPE_USERNAME"),
   System.getenv("SONATYPE_PASSWORD")
 )
@@ -84,7 +84,7 @@ lazy val commonSettings = Seq(
     else
       Some("local-releases".at(s"$artifactory/libs-release-local/"))
   } else {
-    val nexus = "https://oss.sonatype.org/"
+    val nexus = "https://ossrh-staging-api.central.sonatype.com/"
     if (isSnapshot.value) Some("snapshots".at(nexus + "content/repositories/snapshots"))
     else Some("releases".at(nexus + "service/local/staging/deploy/maven2"))
   }),


### PR DESCRIPTION
As of June 30, the Open Source Software Repository Hosting (OSSRH) provided by Sonatype has reached end of life and has been shut down. Ref.: https://central.sonatype.org/pages/ossrh-eol/.

This PR replaces oss.sonatype.org with ossrh-staging-api.central.sonatype.com, as described in the documentation of the Portal OSSRH Staging API: oss.sonatype.org with ossrh-staging-api.central.sonatype.com.

We may need to do more changes, but this is a first try.