### PR TITLE
Change authentication realm to the new OSSRH Staging API Service

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,7 @@ ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix" % "0
 lazy val patchVersion = scala.io.Source.fromFile("patch_version.txt").mkString.trim
 
 credentials += Credentials(
-  "Sonatype Nexus Repository Manager",
+  "OSSRH Staging API Service",
   "ossrh-staging-api.central.sonatype.com",
   System.getenv("SONATYPE_USERNAME"),
   System.getenv("SONATYPE_PASSWORD")


### PR DESCRIPTION
Based on the errors in the [workflow logs](https://github.com/cognitedata/cognite-sdk-scala/actions/runs/16642343972/job/47095901723) of the `publish_sonatype` job, we think that the authentication real of the credentials for `ossrh-staging-api.central.sonatype.com` should be "OSSRH Staging API Service", instead of the "Sonatype Nexus Repository Manager" realm of the old `oss.sonatype.org`.

```
Error:  Unable to find credentials for [OSSRH Staging API Service @ ossrh-staging-api.central.sonatype.com].
Error:    Is one of these realms misspelled for host [ossrh-staging-api.central.sonatype.com]:
Error:    * Sonatype Nexus Repository Manager
Error:  Unable to find credentials for [OSSRH Staging API Service @ ossrh-staging-api.central.sonatype.com].
Error:    Is one of these realms misspelled for host [ossrh-staging-api.central.sonatype.com]:
Error:    * Sonatype Nexus Repository Manager
Error:  java.io.IOException: Server returned HTTP response code: 401 for URL: https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/com/cognite/cognite-sdk-scala_2.13/2.32.911/cognite-sdk-scala_2.13-2.32.911.pom.asc
```

This PR sets "OSSRH Staging API Service" as the realm for `ossrh-staging-api.central.sonatype.com`.