### PR TITLE
sonatype: don't use cross-command for sonaRelease

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -263,4 +263,4 @@ jobs:
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_OSSRH_USER }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
         run: |
-          sbt -Dsbt.log.noformat=true -J-Xmx3G -J-XX:+UseG1GC +publishSigned +sonaRelease
+          sbt -Dsbt.log.noformat=true -J-Xmx3G -J-XX:+UseG1GC +publishSigned sonaRelease


### PR DESCRIPTION
Looks like `+sonaRelease` isn't the right pattern, it results in 3 sonatype deployments of same version, 1 succeeds and 2 fail.

Since 2.13 and 3 got published
https://repo1.maven.org/maven2/com/cognite/cognite-sdk-scala_2.13/2.32.917/ https://repo1.maven.org/maven2/com/cognite/cognite-sdk-scala_3/2.32.917/ let's try using `sonaRelease` without the plus, maybe it still publishes both and doesn't panic

We have lines like
```
	published cognite-sdk-scala_3 to /home/runner/work/cognite-sdk-scala/cognite-sdk-scala/target/sona-staging/com/cognite/cognite-sdk-scala_3/2.32.917.part/cognite-sdk-scala_3-2.32.917.pom.asc
```
so `+publishSigned` stages both 2.13 and 3 in local dir, and then sonaRelease probably picks all them up from there

[CDF-25359]

[CDF-25359]: https://cognitedata.atlassian.net/browse/CDF-25359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ