### PR TITLE
remove sbtPluginPublishLegacyMavenStyle

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ val natchezVersion = "0.3.7"
 lazy val gpgPass = Option(System.getenv("GPG_KEY_PASSWORD"))
 
 ThisBuild / scalafixDependencies += "org.typelevel" %% "typelevel-scalafix" % "0.5.0"
-ThisBuild / sbtPluginPublishLegacyMavenStyle := false
 
 lazy val patchVersion = scala.io.Source.fromFile("patch_version.txt").mkString.trim
 


### PR DESCRIPTION
I added it bcause it was in the doc I found, but I think this is irrelevant because we aren't publishing a plugin