### PR TITLE
add cogniteExternalIdOrInstanceId

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataTypes.scala
@@ -14,9 +14,13 @@ sealed trait CogniteIdOrInstanceId
 sealed trait CogniteId extends CogniteIdOrInstanceId
 sealed trait CogniteExternalIdOrInstanceId
 
-final case class CogniteExternalId(externalId: String) extends CogniteId with CogniteExternalIdOrInstanceId
+final case class CogniteExternalId(externalId: String)
+    extends CogniteId
+    with CogniteExternalIdOrInstanceId
 final case class CogniteInternalId(id: Long) extends CogniteId
-final case class CogniteInstanceId(instanceId: InstanceId) extends CogniteIdOrInstanceId with CogniteExternalIdOrInstanceId
+final case class CogniteInstanceId(instanceId: InstanceId)
+    extends CogniteIdOrInstanceId
+    with CogniteExternalIdOrInstanceId
 final case class InstanceId(space: String, externalId: String)
 
 object CogniteExternalId {


### PR DESCRIPTION
For files (and later sequences?) by instance Id, it'll be possible to fetch them by either instanceId or externalId, but not by cogniteId. 

Therefore it becomes useful to have a trait that refer to these two exclusively

The downside is that it's a bit messy to have so many traits.