### PR TITLE
add trait CogniteExternalIdOrInstanceId

### DIFF
--- a/src/main/scala/com/cognite/sdk/scala/v1/dataTypes.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/dataTypes.scala
@@ -14,9 +14,13 @@ sealed trait CogniteIdOrInstanceId
 sealed trait CogniteId extends CogniteIdOrInstanceId
 sealed trait CogniteExternalIdOrInstanceId
 
-final case class CogniteExternalId(externalId: String) extends CogniteId with CogniteExternalIdOrInstanceId
+final case class CogniteExternalId(externalId: String)
+    extends CogniteId
+    with CogniteExternalIdOrInstanceId
 final case class CogniteInternalId(id: Long) extends CogniteId
-final case class CogniteInstanceId(instanceId: InstanceId) extends CogniteIdOrInstanceId with CogniteExternalIdOrInstanceId
+final case class CogniteInstanceId(instanceId: InstanceId)
+    extends CogniteIdOrInstanceId
+    with CogniteExternalIdOrInstanceId
 final case class InstanceId(space: String, externalId: String)
 
 object CogniteExternalId {


### PR DESCRIPTION
Can be used in cdp-spark-datasource and jetfire for things like files etc.. that can be used using 

in fact, could be used in sdk too for some methods (specifically upload/downloadLink would work in theory) but can be done separately.