### PR TITLE
fix InstancesTest (for now)

### DIFF
--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -32,22 +32,20 @@ import scala.concurrent.duration.DurationInt
 class InstancesTest extends CommonDataModelTestHelper {
   private val space = Utils.SpaceExternalId
 
-  private val edgeNodeContainerExtId = "sdkTest15EdgeNodeContainer2"
-  private val edgeContainerExtId = "sdkTest15EdgeContainer2"
-  private val nodeContainer1ExtId = "sdkTest15NodeContainer3"
-  private val nodeContainer2ExtId = "sdkTest15NodeContainer4"
+  private val edgeNodeContainerExtId = "sdkTest16EdgeNodeContainer2"
+  private val edgeContainerExtId = "sdkTest16EdgeContainer2"
+  private val nodeContainer1ExtId = "sdkTest16NodeContainer3"
+  private val nodeContainer2ExtId = "sdkTest16NodeContainer4"
   private val containerForDirectNodeRelationExtId = Utils.DirectNodeRelationContainerExtId
 
-  private val edgeNodeViewExtId = "sdkTest15EdgeNodeView2"
-  private val edgeViewExtId = "sdkTest15EdgeView3"
-  private val nodeView1ExtId = "sdkTest15NodeView4"
-  private val nodeView2ExtId = "sdkTest15NodeView5"
+  private val edgeNodeViewExtId = "sdkTest16EdgeNodeView2"
+  private val edgeViewExtId = "sdkTest16EdgeView3"
+  private val nodeView1ExtId = "sdkTest16NodeView4"
+  private val nodeView2ExtId = "sdkTest16NodeView5"
   private val viewForDirectNodeRelationExtId = Utils.DirectNodeRelationViewExtId
 
   private val viewVersion = Utils.ViewVersion
 
-//
-  
   it should "CRUD instances with all property types" in {
 
 //    deleteContainers(Seq(


### PR DESCRIPTION
getting

> [info] - should CRUD instances with all property types *** FAILED *** (19 seconds, 773 milliseconds)
[info]   com.cognite.sdk.scala.common.CdpApiException: Request with id 434be0f0-eff7-9d78-866c-e771ac2ffe57 to https://bluefield.cognitedata.com/api/v1/projects/extractor-bluefield-testing/models/views failed with status 400: Cannot add property 'Float64NonListWithDefaultValueNullable' to view 'testSpaceScalaSdk1:sdkTest15EdgeNodeView2/v1' as the container 'testSpaceScalaSdk1:sdkTest15EdgeNodeContainer2' is not already mapped in this view version. Bump the view version to make this change..

[CDF-26313]

[CDF-26313]: https://cognitedata.atlassian.net/browse/CDF-26313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ