### PR TITLE
remove pointless additional flags flow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.36." + patchVersion,
+  version := "2.37." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   scalaVersion := scala213, // use 2.13 by default
   // handle cross plugin https://github.com/stringbean/sbt-dependency-lock/issues/13

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/instances.scala
@@ -65,7 +65,7 @@ final case class InstanceQueryRequest(
     cursors: Option[Map[String, String]] = None,
     select: Map[String, SelectExpression] = Map.empty,
     includeTyping: Option[Boolean] = Some(true),
-    debug: Option[InstanceDebugParameters] = None,
+    debug: Option[InstanceDebugParameters] = None
 )
 
 final case class InstanceSyncRequest(

--- a/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/fdm/instances/instances.scala
@@ -66,7 +66,6 @@ final case class InstanceQueryRequest(
     select: Map[String, SelectExpression] = Map.empty,
     includeTyping: Option[Boolean] = Some(true),
     debug: Option[InstanceDebugParameters] = None,
-    additionalFlags: Map[String, Boolean] = Map.empty
 )
 
 final case class InstanceSyncRequest(

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
@@ -63,7 +63,6 @@ class Instances[F[_]](val requestSession: RequestSession[F])
       limit: Option[Int],
       debug: Option[InstanceDebugParameters],
       @annotation.nowarn partition: Option[Partition] = None,
-      additionalFlags: Map[String, Boolean]
   )(implicit F: Async[F]): F[ItemsWithCursor[InstanceDefinition]] = {
     val resultName = "query"
     queryRequest(
@@ -75,7 +74,6 @@ class Instances[F[_]](val requestSession: RequestSession[F])
         cursors = cursor.map(c => Map(resultName -> c)),
         select = Map(resultName -> inputSelectExpression),
         debug = debug,
-        additionalFlags = additionalFlags
       )
     ).map { case InstanceQueryResponse(items, _, cursors, _) =>
       ItemsWithCursor(
@@ -91,7 +89,6 @@ class Instances[F[_]](val requestSession: RequestSession[F])
       limit: Option[Int],
       batchSize: Option[Int] = None,
       debug: Option[InstanceDebugParameters] = None,
-      additionalFlags: Map[String, Boolean] = Map.empty
   )(implicit F: Async[F]): Stream[F, InstanceDefinition] =
     Readable
       .pullFromCursor(
@@ -107,7 +104,6 @@ class Instances[F[_]](val requestSession: RequestSession[F])
             limit = remaining,
             partition = partition,
             debug = debug,
-            additionalFlags = additionalFlags
           )
       )
       .stream
@@ -183,15 +179,7 @@ object Instances {
     }
   implicit val instanceQueryRequestEncoder: Encoder[InstanceQueryRequest] =
     deriveEncoder[InstanceQueryRequest].mapJsonObject { jsonObj =>
-      val additionalFields = jsonObj("additionalFlags")
-        .flatMap(_.asObject)
-        .getOrElse(JsonObject.empty)
-
-      // Order or merge is important, we want jsonObj properties to stay in case of conflicts
-      // additionalFlags only contains boolean so deepMerge will go a single level, if this is changed, change this logic too.
-      additionalFields
-        .deepMerge(jsonObj.remove("additionalFlags"))
-        .filter { case (_, v) => !v.isNull }
+      jsonObj.filter { case (_, v) => !v.isNull }
     }
   implicit val tableExpression: Encoder[TableExpression] =
     deriveEncoder[TableExpression].mapJsonObject { jsonObj =>

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
@@ -62,7 +62,7 @@ class Instances[F[_]](val requestSession: RequestSession[F])
       cursor: Option[String],
       limit: Option[Int],
       debug: Option[InstanceDebugParameters],
-      @annotation.nowarn partition: Option[Partition] = None,
+      @annotation.nowarn partition: Option[Partition] = None
   )(implicit F: Async[F]): F[ItemsWithCursor[InstanceDefinition]] = {
     val resultName = "query"
     queryRequest(
@@ -73,7 +73,7 @@ class Instances[F[_]](val requestSession: RequestSession[F])
         ),
         cursors = cursor.map(c => Map(resultName -> c)),
         select = Map(resultName -> inputSelectExpression),
-        debug = debug,
+        debug = debug
       )
     ).map { case InstanceQueryResponse(items, _, cursors, _) =>
       ItemsWithCursor(
@@ -88,7 +88,7 @@ class Instances[F[_]](val requestSession: RequestSession[F])
       inputSelectExpression: SelectExpression,
       limit: Option[Int],
       batchSize: Option[Int] = None,
-      debug: Option[InstanceDebugParameters] = None,
+      debug: Option[InstanceDebugParameters] = None
   )(implicit F: Async[F]): Stream[F, InstanceDefinition] =
     Readable
       .pullFromCursor(
@@ -103,7 +103,7 @@ class Instances[F[_]](val requestSession: RequestSession[F])
             cursor = cursor,
             limit = remaining,
             partition = partition,
-            debug = debug,
+            debug = debug
           )
       )
       .stream

--- a/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
+++ b/src/main/scala/com/cognite/sdk/scala/v1/resources/fdm/instances/instances.scala
@@ -10,7 +10,7 @@ import com.cognite.sdk.scala.v1.RequestSession
 import com.cognite.sdk.scala.v1.fdm.instances._
 import fs2.Stream
 import io.circe.generic.semiauto.{deriveDecoder, deriveEncoder}
-import io.circe.{Decoder, Encoder, JsonObject, Printer}
+import io.circe.{Decoder, Encoder, Printer}
 import sttp.client3._
 import sttp.client3.circe._
 

--- a/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/v1/fdm/instances/InstancesTest.scala
@@ -217,7 +217,6 @@ class InstancesTest extends CommonDataModelTestHelper {
         )))),
       SelectExpression(sources = List()),
       limit = Some(3),
-      additionalFlags = Map.empty,
       batchSize = Some(1)
     ).compile.toList.unsafeRunSync()
 
@@ -378,7 +377,6 @@ class InstancesTest extends CommonDataModelTestHelper {
           )))
         ),
         includeTyping = Some(true),
-        additionalFlags = Map.empty,
         debug = Some(InstanceDebugParameters(
           emitResults = Some(false),
           timeout = None


### PR DESCRIPTION
Additional flags were added to handle potentially complicated additional flag we though we needed.

Sivert has confirmed we don't need it, we also indpendently concluded that we don't otherwize the is_new flow wouldn't work.