### PR TITLE
INC-2725: allow empty resourceAcl

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -46,7 +46,7 @@ lazy val commonSettings = Seq(
   organization := "com.cognite",
   organizationName := "Cognite",
   organizationHomepage := Some(url("https://cognite.com")),
-  version := "2.36." + patchVersion,
+  version := "2.37." + patchVersion,
   isSnapshot := patchVersion.endsWith("-SNAPSHOT"),
   scalaVersion := scala213, // use 2.13 by default
   // handle cross plugin https://github.com/stringbean/sbt-dependency-lock/issues/13

--- a/src/main/scala/com/cognite/sdk/scala/common/token.scala
+++ b/src/main/scala/com/cognite/sdk/scala/common/token.scala
@@ -70,14 +70,6 @@ object ProjectCapability {
           h.history
         )
       )
-      _ <- Either.cond(
-        acls.nonEmpty,
-        (),
-        DecodingFailure(
-          DecodingFailure.Reason.CustomReason("capability must have some resourceAcl"),
-          h.history
-        )
-      )
     } yield new ProjectCapability(acls, projectScope)
   }
   implicit val encoder: Encoder[ProjectCapability] = Encoder.instance {

--- a/src/test/scala/com/cognite/sdk/scala/common/TokenParsingTest.scala
+++ b/src/test/scala/com/cognite/sdk/scala/common/TokenParsingTest.scala
@@ -34,13 +34,13 @@ class TokenParsingTest extends AnyFlatSpec with Matchers {
     )
     r shouldBe Right(ProjectsListScope(Seq("a")))
   }
-  it should "require *Acl field" in {
+  it should "not require *Acl field" in {
     val r = ProjectCapability.decoder.decodeJson(json"""
       {
         "projectScope": {"allProjects": {}}
       }
     """)
-    r.isLeft shouldBe true
+    r.isLeft shouldBe false
   }
   it should "decode allProjects capability" in {
     val r = ProjectCapability.decoder.decodeJson(json"""


### PR DESCRIPTION
Some acls can become deprecated and disappear from capabilities, for
more consistency during such changes let's remove sanity check and
accept "no acls" in decoder
