### PR TITLE
.github/workflows/scala.yml: add manual workflow_dispatch trigger

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 jobs:
   compile_scala_213:


### PR DESCRIPTION
MIght allow manually forcing a build for PR created by bot and contributed-to by bot, like https://github.com/cognitedata/cognite-sdk-scala/pull/947