### PR TITLE
Revert "Update codecov/codecov-action action to v7 (#967)"

### DIFF
--- a/.github/workflows/scala.yml
+++ b/.github/workflows/scala.yml
@@ -142,7 +142,7 @@ jobs:
         cat /dev/null | sbt -Dsbt.log.noformat=true -J-Xmx4G -J-XX:+UseG1GC ++3.3 scalafmtCheck scalafmtSbtCheck test
 
     - name: Upload test coverage report
-      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
+      uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6
       with:
         token: ${{ secrets.codecov_token }}
 


### PR DESCRIPTION
This reverts commit 149415df10eb364ddfa52d94d7b61ce5b9431349.

This is done to investigate if codecov upgrade caused CI/CD failures